### PR TITLE
Quick little enhancement of dark theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,11 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme_miLight">
+        android:theme="@style/AppTheme_miDark">
+        <!--
+            Better if app starts dark and turns white than blinds you with white splash screen
+            before it turns dark.
+        -->
         <activity
             android:name=".ActivityMisMangas"
             android:configChanges="orientation"

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityDetails.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityDetails.java
@@ -38,16 +38,14 @@ public class ActivityDetails extends ActionBarActivity {
     Manga m;
     FloatingActionButton button_add;
     SharedPreferences pm;
-    boolean lightTheme;
+    boolean darkTheme;
 
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
-        lightTheme = pm.getBoolean("dark_theme", false);
-        if (lightTheme) {
-            setTheme(R.style.AppTheme_miLight);
-        }
+        darkTheme = pm.getBoolean("dark_theme", false);
+        setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_detalles);
         data = (ControlInfo) findViewById(R.id.datos);
@@ -155,7 +153,6 @@ public class ActivityDetails extends ActionBarActivity {
             }
             str.setRefreshing(false);
         }
-
     }
 
     public class AddMangaTask extends AsyncTask<Manga, Integer, Void> {

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityDetails.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityDetails.java
@@ -38,15 +38,15 @@ public class ActivityDetails extends ActionBarActivity {
     Manga m;
     FloatingActionButton button_add;
     SharedPreferences pm;
-    boolean darkTheme;
+    boolean lightTheme;
 
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
-        darkTheme = pm.getBoolean("dark_theme", false);
-        if (darkTheme) {
-            setTheme(R.style.AppBaseThemeDark);
+        lightTheme = pm.getBoolean("dark_theme", false);
+        if (lightTheme) {
+            setTheme(R.style.AppTheme_miLight);
         }
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_detalles);
@@ -214,7 +214,7 @@ public class ActivityDetails extends ActionBarActivity {
             try {
                 onBackPressed();
             } catch (Exception e) {
-
+                // Catch nothing.
             }
             super.onPostExecute(result);
         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityDownloads.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityDownloads.java
@@ -27,9 +27,8 @@ public class ActivityDownloads extends ActionBarActivity {
     protected void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
         darkTheme = pm.getBoolean("dark_theme", false);
-        if (darkTheme) {
-            setTheme(R.style.AppBaseThemeDark);
-        }
+        setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_descargas);
         int[] colors = ThemeColors.getColors(

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityDownloads.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityDownloads.java
@@ -28,7 +28,6 @@ public class ActivityDownloads extends ActionBarActivity {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
         darkTheme = pm.getBoolean("dark_theme", false);
         setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
-
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_descargas);
         int[] colors = ThemeColors.getColors(

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityLicenseView.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityLicenseView.java
@@ -25,9 +25,7 @@ public class ActivityLicenseView extends ActionBarActivity {
     protected void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
         darkTheme = pm.getBoolean("dark_theme", false);
-        if (darkTheme) {
-            setTheme(R.style.AppBaseThemeDark);
-        }
+        setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_licence);
         lic = (TextView) findViewById(R.id.licencia);

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityManga.java
@@ -57,9 +57,8 @@ public class ActivityManga extends ActionBarActivity {
     protected void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
         darkTheme = pm.getBoolean("dark_theme", false);
-        if (darkTheme) {
-            setTheme(R.style.AppBaseThemeDark);
-        }
+        setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_manga);
         id = getIntent().getExtras().getInt(ActivityMisMangas.MANGA_ID, -1);

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityManga.java
@@ -58,7 +58,6 @@ public class ActivityManga extends ActionBarActivity {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
         darkTheme = pm.getBoolean("dark_theme", false);
         setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
-
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_manga);
         id = getIntent().getExtras().getInt(ActivityMisMangas.MANGA_ID, -1);

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityMisMangas.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityMisMangas.java
@@ -46,9 +46,7 @@ public class ActivityMisMangas extends ActionBarActivity implements OnClickListe
     protected void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(ActivityMisMangas.this);
         darkTheme = pm.getBoolean("dark_theme", false);
-        if (darkTheme) {
-            setTheme(R.style.AppBaseThemeDark);
-        }
+        setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
         super.onCreate(savedInstanceState);
         PreferenceManager.setDefaultValues(this, R.xml.fragment_preferences, false);
         setContentView(R.layout.activity_mis_mangas);

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityResultadoDeBusqueda.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityResultadoDeBusqueda.java
@@ -34,9 +34,7 @@ public class ActivityResultadoDeBusqueda extends ActionBarActivity {
     protected void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
         darkTheme = pm.getBoolean("dark_theme", false);
-        if (darkTheme) {
-            setTheme(R.style.AppBaseThemeDark);
-        }
+        setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_activity_resultado_de_busqueda);
         serverId = getIntent().getExtras().getInt(ActivityMisMangas.SERVER_ID);
@@ -44,7 +42,6 @@ public class ActivityResultadoDeBusqueda extends ActionBarActivity {
         lista = (ListView) findViewById(R.id.resultados);
         cargando = (ProgressBar) findViewById(R.id.cargando);
         lista.setOnItemClickListener(new OnItemClickListener() {
-
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 Manga m = (Manga) lista.getAdapter().getItem(position);
@@ -53,7 +50,6 @@ public class ActivityResultadoDeBusqueda extends ActionBarActivity {
                 intent.putExtra(ActivityDetails.TITLE, m.getTitle());
                 intent.putExtra(ActivityDetails.PATH, m.getPath());
                 startActivity(intent);
-
             }
         });
         new PerformSearchTask().execute();
@@ -71,7 +67,7 @@ public class ActivityResultadoDeBusqueda extends ActionBarActivity {
 
         @Override
         protected ArrayList<Manga> doInBackground(Void... params) {
-            ArrayList<Manga> mangas = new ArrayList<Manga>();
+            ArrayList<Manga> mangas = new ArrayList<>();
             ServerBase s = ServerBase.getServer(serverId);
             try {
                 mangas = s.search(termino);
@@ -86,7 +82,7 @@ public class ActivityResultadoDeBusqueda extends ActionBarActivity {
             cargando.setVisibility(ProgressBar.INVISIBLE);
             if (error.length() < 2) {
                 if (result != null && !result.isEmpty() && lista != null) {
-                    lista.setAdapter(new ArrayAdapter<Manga>(ActivityResultadoDeBusqueda.this, android.R.layout.simple_list_item_1, result));
+                    lista.setAdapter(new ArrayAdapter<>(ActivityResultadoDeBusqueda.this, android.R.layout.simple_list_item_1, result));
                 } else if (result == null || result.isEmpty()) {
                     Toast.makeText(ActivityResultadoDeBusqueda.this, getResources().getString(R.string.busquedanores), Toast.LENGTH_LONG).show();
                 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityServerListadeMangas.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityServerListadeMangas.java
@@ -40,9 +40,7 @@ public class ActivityServerListadeMangas extends ActionBarActivity {
     protected void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
         darkTheme = pm.getBoolean("dark_theme", false);
-        if (darkTheme) {
-            setTheme(R.style.AppBaseThemeDark);
-        }
+        setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_server_lista_de_mangas);
         int id = getIntent().getExtras().getInt(ActivityMisMangas.SERVER_ID);

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityServerVisualNavegacion.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityServerVisualNavegacion.java
@@ -51,9 +51,7 @@ public class ActivityServerVisualNavegacion extends ActionBarActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(ActivityServerVisualNavegacion.this);
         darkTheme = pm.getBoolean("dark_theme", false);
-        if (darkTheme) {
-            setTheme(R.style.AppBaseThemeDark);
-        }
+        setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_server_visual_navegacion);
         int id = getIntent().getExtras().getInt(ActivityMisMangas.SERVER_ID);
@@ -66,12 +64,12 @@ public class ActivityServerVisualNavegacion extends ActionBarActivity implements
         int[] colors = ThemeColors.getColors(PreferenceManager.getDefaultSharedPreferences(getApplicationContext()), getApplicationContext());
         getSupportActionBar().setBackgroundDrawable(new ColorDrawable(colors[0]));
         if (s.getCategories() != null)
-            generos.setAdapter(new ArrayAdapter<String>(this, android.R.layout.simple_dropdown_item_1line, s.getCategories()));
+            generos.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_dropdown_item_1line, s.getCategories()));
         else
             generos.setVisibility(Spinner.INVISIBLE);
 
         if (s.getOrders() != null)
-            orden.setAdapter(new ArrayAdapter<String>(this, android.R.layout.simple_dropdown_item_1line, s.getOrders()));
+            orden.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_dropdown_item_1line, s.getOrders()));
         else
             orden.setVisibility(Spinner.INVISIBLE);
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/OpcionesActivity.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/OpcionesActivity.java
@@ -30,9 +30,7 @@ public class OpcionesActivity extends PreferenceActivity {
     public void onCreate(Bundle savedInstanceState) {
         pm = PreferenceManager.getDefaultSharedPreferences(this);
         darkTheme = pm.getBoolean("dark_theme", false);
-        if (darkTheme) {
-            setTheme(R.style.AppBaseThemeDark);
-        }
+        setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.fragment_preferences);
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -133,7 +133,7 @@
     <string name="color_secundario_sub">Sekundäre Farbe für mehr Abwechselung</string>
     <string name="about">Über</string>
     <string name="scroll_speed">Scroll-Geschwindigkeit</string>
-    <string name="theme_title">Verwenden dunkles Thema</string>
+    <string name="theme_title">Verwende dunkles Thema</string>
     <string name="download_selection">Kapitel herunterladen</string>
     <string name="sort">Sortieren</string>
     <string name="sort_title">Titel</string>
@@ -142,5 +142,5 @@
     <string name="sort_author_asc">Autor (z-a)</string>
     <string name="sort_recent_asc">Zuletzt gelesen (älteste)</string>
     <string name="sort_title_asc">Titel (z-a)</string>
-    <string name="more_options">Mehr Optionen </string>
+    <string name="more_options">Mehr Optionen</string>
 </resources>

--- a/app/src/main/res/values/colores_arrays.xml
+++ b/app/src/main/res/values/colores_arrays.xml
@@ -42,27 +42,39 @@
         <item>#9F9F9C</item>
         <item>#51808F</item>
         <item>#100C08</item>
+
+        <item>#413839</item>
+        <item>#151B54</item>
+        <item>#483D8B</item>
+        <item>#915c83</item>
+        <item>#336666</item>
     </string-array>
 
     <string-array name="color_names">
         <item>Red Orange</item>
         <item>Razzmatazz</item>
-        <item>Dark orchid</item>
+        <item>Dark Orchid</item>
         <item>Purple Heart</item>
         <item>Cerulean Blue</item>
         <item>Dodger Blue</item>
         <item>Cyan</item>
         <item>Gossamer</item>
         <item>Apple</item>
-        <item>Dollar bill</item>
+        <item>Dollar Bill</item>
         <item>Pear</item>
-        <item>Mikado yellow</item>
+        <item>Mikado Yellow</item>
         <item>Orange</item>
         <item>Flamingo</item>
         <item>Roman Coffee</item>
         <item>Star Dust</item>
         <item>Smalt Blue</item>
-        <item>Smoky black</item>
+        <item>Smoky Black</item>
+
+        <item>Black Cat</item>
+        <item>Midnight Blue</item>
+        <item>Dark Slate Blue</item>
+        <item>Antique Fuchsia</item>
+        <item>Dark Slate Gray</item>
     </string-array>
 
     <string-array name="backgroungs" translatable="false">


### PR DESCRIPTION
It is great that raulhaag started to do dark theme,
* change the usage of dark and light theme a bit, so it becomes really dark or really light
* starting theme is always dark, because of reasons, read code or http://cyrilmottier.com/2013/01/23/android-app-launching-made-gorgeous/
* I spontaneously added some darker colors for more dark theme variety.. **but** I think I'll have to rewrite the color picker part, because a list isn't great.. (except the funny names the colors have)

What's still to do or improve with this commit:
* Sometimes the text is not easy to read with dark theme, maybe the Detail needs a re-design?
* Maybe an improvement, so you can configure each manga separately (zoom level, update, factor etc.)