### PR TITLE
Fix cut-off text in List of Manga

### DIFF
--- a/app/src/main/res/layout/listitem_server_manga.xml
+++ b/app/src/main/res/layout/listitem_server_manga.xml
@@ -14,5 +14,5 @@
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"
         android:padding="@dimen/paddin_textitem"
-        android:textSize="@dimen/tamano_texto" />
+        android:textSize="@dimen/tamano_texto_dp" />
 </RelativeLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="paddin_textitem">6dp</dimen>
     <dimen name="tamano_texto">18sp</dimen>
+    <dimen name="tamano_texto_dp">18dp</dimen>
     <dimen name="padding_recycleview">-4dp</dimen>
 
     <!-- Some font and margin sizes for dialogs -->


### PR DESCRIPTION
Using sp can result in cut-off text if the device's text setting is large.

New text size value of 18dp was added to dimens and the text of List Of Manga's textviews were changed to use this value.