### PR TITLE
Minor fix, minor feature add

### DIFF
--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivitySettings.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivitySettings.java
@@ -198,7 +198,7 @@ public class ActivitySettings extends AppCompatActivity {
                 prefStoreStat.setSummary(
                         String.format("%.2f", (l[0] - l[1] - l[2]) / (1024.0 * 1024.0)) + " MB");
                 prefCacheStat.setSummary(
-                        String.format("%.2f", l[2] / (1024.0 * 1024.0)) + " MB");
+                        String.format("%.2f", l[1] / (1024.0 * 1024.0)) + " MB");
 
                 super.onPostExecute(l);
             }

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivitySettings.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivitySettings.java
@@ -22,8 +22,6 @@ import com.fedorvlasov.lazylist.FileCache;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
 
 import ar.rulosoft.custompref.SeekBarDialogPref;
 import ar.rulosoft.mimanganu.services.AlarmReceiver;

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivitySettings.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivitySettings.java
@@ -3,6 +3,7 @@ package ar.rulosoft.mimanganu;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.drawable.ColorDrawable;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
@@ -12,9 +13,12 @@ import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.SwitchPreference;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.Window;
+
+import com.fedorvlasov.lazylist.FileCache;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,14 +34,14 @@ public class ActivitySettings extends AppCompatActivity {
     private boolean darkTheme;
 
     public void onCreate(Bundle savedInstanceState) {
-        SharedPreferences pm = PreferenceManager.getDefaultSharedPreferences(this);
-        darkTheme = pm.getBoolean("dark_theme", false);
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        darkTheme = prefs.getBoolean("dark_theme", false);
         setTheme(darkTheme ? R.style.AppTheme_miDark : R.style.AppTheme_miLight);
         super.onCreate(savedInstanceState);
         getFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new PreferencesFragment()).commit();
-        int[] colors = ThemeColors.getColors(pm, getApplicationContext());
-        android.support.v7.app.ActionBar mActBar = getSupportActionBar();
+        int[] colors = ThemeColors.getColors(prefs, getApplicationContext());
+        ActionBar mActBar = getSupportActionBar();
         if (mActBar != null) {
             mActBar.setBackgroundDrawable(new ColorDrawable(colors[0]));
             mActBar.setDisplayHomeAsUpEnabled(true);
@@ -63,6 +67,8 @@ public class ActivitySettings extends AppCompatActivity {
     }
 
     public static class PreferencesFragment extends PreferenceFragment {
+        private SharedPreferences prefs;
+        private FileCache mFileStorage;
 
         @Override
         public void onCreate(Bundle savedInstanceState) {
@@ -70,21 +76,37 @@ public class ActivitySettings extends AppCompatActivity {
             super.onCreate(savedInstanceState);
             addPreferencesFromResource(R.xml.fragment_preferences);
 
-            /** This enables to hide finished mangas, just a toggle */
+            /** Once, create necessary Data */
+            prefs = PreferenceManager
+                    .getDefaultSharedPreferences(getActivity().getApplicationContext());
+            final String current_filepath = prefs.getString("directorio",
+                    Environment.getExternalStorageDirectory().getAbsolutePath()) + "/MiMangaNu/";
+
+            /** This enables to hide downloaded images from gallery, just a toggle */
             final SwitchPreference cBoxPref =
                     (SwitchPreference) getPreferenceManager().findPreference("mostrar_en_galeria");
             cBoxPref.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    boolean valor = (Boolean) newValue;
-                    File f = new File(Environment.getExternalStorageDirectory().getAbsolutePath() +
-                            "/MiMangaNu/", ".nomedia");
-                    if (valor) if (f.exists()) f.delete();
-                    else if (!f.exists()) try {
-                        f.createNewFile();
-                    } catch (IOException e) {
-                        e.printStackTrace();
+                    boolean have_noMedia = (Boolean) newValue;
+
+                    if (android.os.Environment.getExternalStorageState()
+                            .equals(android.os.Environment.MEDIA_MOUNTED)) {
+                        File mimaFolder = new File(current_filepath, ".nomedia");
+
+                        if (have_noMedia) {
+                            try {
+                                mimaFolder.createNewFile();
+                            } catch (IOException e) {
+                                e.printStackTrace();
+                            }
+                        } else {
+                            if (mimaFolder.exists()) {
+                                mimaFolder.delete();
+                            }
+                        }
                     }
+
                     return true;
                 }
             });
@@ -145,12 +167,41 @@ public class ActivitySettings extends AppCompatActivity {
             });
 
             /** This.. sets the Version Number, that's all */
-            Preference prefAbout =
-                    getPreferenceManager().findPreference("about_text");
+            final Preference prefAbout = getPreferenceManager().findPreference("about_text");
             prefAbout.setSummary("v" + BuildConfig.VERSION_NAME);
 
-            Preference prefLicense = getPreferenceManager().findPreference("license_view");
+            /** This will check how much storage is taken by the mangas */
+            new calcStorage().execute(current_filepath);
+
+            final Preference prefLicense = getPreferenceManager().findPreference("license_view");
             prefLicense.setIntent(new Intent(getActivity(), ActivityLicenseView.class));
+        }
+
+        public class calcStorage extends AsyncTask<String, Void, Long[]> {
+            @Override
+            protected Long[] doInBackground(String... strings) {
+                mFileStorage = new FileCache(getActivity().getApplicationContext());
+                long store_total = mFileStorage.dirSize(new File(strings[0]));
+                long store_cache = mFileStorage.dirSize(new File(strings[0], "cache"));
+                long store_dbs = mFileStorage.dirSize(new File(strings[0], "dbs"));
+
+                return new Long[]{store_total, store_cache, store_dbs};
+            }
+
+            @Override
+            protected void onPostExecute(Long[] l) {
+                Preference prefStoreStat =
+                        getPreferenceManager().findPreference("stat_storage");
+                Preference prefCacheStat =
+                        getPreferenceManager().findPreference("stat_cache");
+
+                prefStoreStat.setSummary(
+                        String.format("%.2f", (l[0] - l[1] - l[2]) / (1024.0 * 1024.0)) + " MB");
+                prefCacheStat.setSummary(
+                        String.format("%.2f", l[2] / (1024.0 * 1024.0)) + " MB");
+
+                super.onPostExecute(l);
+            }
         }
 
     }

--- a/app/src/main/java/com/fedorvlasov/lazylist/FileCache.java
+++ b/app/src/main/java/com/fedorvlasov/lazylist/FileCache.java
@@ -9,6 +9,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.LinkedList;
+import java.util.List;
 
 public class FileCache {
     private File cacheDir;
@@ -22,8 +24,9 @@ public class FileCache {
             cacheDir = new File(dir, "cache");
         else
             cacheDir = context.getCacheDir();
-        if (!cacheDir.exists())
-            cacheDir.mkdirs();
+        if (!cacheDir.exists()) {
+            boolean created = cacheDir.mkdirs();
+        }
     }
 
     public static void writeFile(InputStream is, File f) {
@@ -54,35 +57,41 @@ public class FileCache {
     }
 
     /**
-     * Calculate size of folder recursively.
+     * Calculate size of folder.
      *
      * @param folder your directory to check
      * @return totalSize
      */
-    public long dirSize(File folder) {
-        if (folder.exists()) {
-            long totalSize = 0;
-            File[] fileList = folder.listFiles();
-            for (File aFileList : fileList) {
-                if (aFileList.isDirectory()) {
-                    // It's a folder, then recursively dive into it
-                    totalSize += dirSize(aFileList);
-                } else {
-                    // Sum file size in byte
-                    totalSize += aFileList.length();
-                }
+    public long dirSize(final File folder) {
+        if (folder == null || !folder.exists())
+            return 0;
+        if (!folder.isDirectory())
+            return folder.length();
+        final List<File> dirs = new LinkedList<>();
+        dirs.add(folder);
+        long result = 0;
+        while (!dirs.isEmpty()) {
+            final File dir = dirs.remove(0);
+            if (!dir.exists())
+                continue;
+            final File[] listFiles = dir.listFiles();
+            if (listFiles == null || listFiles.length == 0)
+                continue;
+            for (final File child : listFiles) {
+                result += child.length();
+                if (child.isDirectory())
+                    dirs.add(child);
             }
-            return totalSize;
         }
-        return 0;
+        return result;
     }
 
-    public void clear() {
+    public void clearCache() {
         File[] files = cacheDir.listFiles();
         if (files == null)
             return;
-        for (File f : files)
-            f.delete();
+        for (File f : files) {
+            boolean deleted = f.delete();
+        }
     }
-
 }

--- a/app/src/main/java/com/fedorvlasov/lazylist/FileCache.java
+++ b/app/src/main/java/com/fedorvlasov/lazylist/FileCache.java
@@ -7,7 +7,6 @@ import android.preference.PreferenceManager;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -33,7 +32,7 @@ public class FileCache {
             int buffer_size = 1024;
             try {
                 byte[] bytes = new byte[buffer_size];
-                for (;;) {
+                for (; ; ) {
                     int count = is.read(bytes, 0, buffer_size);
                     if (count == -1)
                         break;
@@ -52,6 +51,30 @@ public class FileCache {
         //I identify images by hashcode. Not a perfect solution, good for the demo.
         String filename = String.valueOf(url.hashCode());
         return new File(cacheDir, filename);
+    }
+
+    /**
+     * Calculate size of folder recursively.
+     *
+     * @param folder your directory to check
+     * @return totalSize
+     */
+    public long dirSize(File folder) {
+        if (folder.exists()) {
+            long totalSize = 0;
+            File[] fileList = folder.listFiles();
+            for (File aFileList : fileList) {
+                if (aFileList.isDirectory()) {
+                    // It's a folder, then recursively dive into it
+                    totalSize += dirSize(aFileList);
+                } else {
+                    // Sum file size in byte
+                    totalSize += aFileList.length();
+                }
+            }
+            return totalSize;
+        }
+        return 0;
     }
 
     public void clear() {

--- a/app/src/main/res/xml/fragment_preferences.xml
+++ b/app/src/main/res/xml/fragment_preferences.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:key="first_preferencescreen">+
+    android:key="first_preferencescreen">
 
     <PreferenceCategory android:title="Test">
         <SwitchPreference
@@ -145,6 +145,14 @@
             android:key="about_text"
             android:summary="%s"
             android:title="@string/app_name" />
+        <Preference
+            android:key="stat_storage"
+            android:summary="..."
+            android:title="Used storage" />
+        <Preference
+            android:key="stat_cache"
+            android:summary="..."
+            android:title="Used cache" />
         <Preference
             android:key="license_view"
             android:summary="@string/license_sub"

--- a/app/src/main/res/xml/fragment_preferences.xml
+++ b/app/src/main/res/xml/fragment_preferences.xml
@@ -148,11 +148,7 @@
         <Preference
             android:key="stat_storage"
             android:summary="..."
-            android:title="Used storage" />
-        <Preference
-            android:key="stat_cache"
-            android:summary="..."
-            android:title="Used cache" />
+            android:title="Storage size used by mangas" />
         <Preference
             android:key="license_view"
             android:summary="@string/license_sub"


### PR DESCRIPTION
This time, the gallery hide toggle is fixed, now it works properly even if you change the directory.
Added a directory size calculator and an entry in "about" to see the current size of storage taken by locally saved mangas.