### PR TITLE
small changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *FR - Lecteur de manga en ligne / hors ligne, gratuit et open source.
 
-*DE - MiMangaNu ist ein Manga Lese App. Man kann damit Manga Online und Offline lesen. Es ist Frei und open source.
+*DE - MiMangaNu ist ein App um Manga zu lesen. Man kann damit Manga Online und Offline lesen. Es ist kostenlos und quelloffen.
 
 *IT - Manga lettore online / offline, gratuito e open source.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *FR - Lecteur de manga en ligne / hors ligne, gratuit et open source.
 
-*DE - MiMangaNu ist ein App um Manga zu lesen. Man kann damit Manga Online und Offline lesen. Es ist kostenlos und quelloffen.
+*DE - Eine App um Manga zu lesen. Man kann damit Manga online und offline lesen. Es ist kostenlos und quelloffen.
 
 *IT - Manga lettore online / offline, gratuito e open source.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
+        android:largeHeap="true"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
@@ -562,7 +562,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
                                     .getString(R.string.mgs_update_found), result));
                     mNotifyManager.notify(mNotifyID, mBuilder.build());
                     setListManga(true);
-                    Toast.makeText(mContent, mContent.getResources().getString(R.string.mgs_update_found,result),Toast.LENGTH_LONG).show();
+                    Toast.makeText(mContent, mContent.getResources().getString(R.string.mgs_update_found, result), Toast.LENGTH_LONG).show();
                 } else {
                     mNotifyManager.cancel(mNotifyID);
                     Toast.makeText(mContent, mContent.getResources().getString(R.string.no_new_updates_found),Toast.LENGTH_LONG).show();

--- a/app/src/main/java/ar/rulosoft/mimanganu/MangaFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MangaFragment.java
@@ -595,7 +595,7 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
                 getActivity().setTitle(orgMsg);
             }
             if (result > 0) {
-                Toast.makeText(getActivity(), result + " " + getString(R.string.new_chapters_found), Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), getString(R.string.mgs_update_found, result), Toast.LENGTH_SHORT).show();
             } else if (errorMsg != null && errorMsg.length() > 2) {
                 Toast.makeText(getActivity(), errorMsg, Toast.LENGTH_SHORT).show();
             }

--- a/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
@@ -186,10 +186,10 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
             // This is a new install or upgrade
 
             // set number of manual search threads = number of cores
-            setNumberOfThreadsToBeEqualToNumberOfCores(8, "update_threads_manual");
+            setNumberOfThreadsToBeEqualToNumberOfCores(4, "update_threads_manual");
 
             // set number of download threads = number of cores
-            setNumberOfThreadsToBeEqualToNumberOfCores(8, "download_threads");
+            setNumberOfThreadsToBeEqualToNumberOfCores(4, "download_threads");
         }
         // Update the shared preferences with the current version code
         prefs.edit().putInt(PREF_VERSION_CODE_KEY, currentVersionCode).apply();

--- a/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
@@ -13,7 +13,6 @@ import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
 import android.support.v7.preference.SwitchPreferenceCompat;
 import android.view.MenuItem;
-import android.widget.Toast;
 
 import com.fedorvlasov.lazylist.FileCache;
 
@@ -183,26 +182,32 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
         if (currentVersionCode == savedVersionCode) {
             // This is just a normal run
             return;
-        } else if (savedVersionCode == DOESNT_EXIST || currentVersionCode > savedVersionCode)  {
+        } else if (savedVersionCode == DOESNT_EXIST || currentVersionCode > savedVersionCode) {
             // This is a new install or upgrade
 
-            //set number of manual search threads = number of cores
-            int manualSearchThreadsMax = 8, manualSearchThreads;
-            if (Runtime.getRuntime().availableProcessors() <= manualSearchThreadsMax) {
-                manualSearchThreads = Runtime.getRuntime().availableProcessors();
-            } else {
-                manualSearchThreads = manualSearchThreadsMax;
-            }
-            SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-            SharedPreferences.Editor editor = preferences.edit();
-            editor.putString("update_threads_manual", "" + manualSearchThreads);
-            editor.apply();
+            // set number of manual search threads = number of cores
+            setNumberOfThreadsToBeEqualToNumberOfCores(8, "update_threads_manual");
 
-            final SeekBarPreference2 listPreferenceMT = (SeekBarPreference2) getPreferenceManager().findPreference("update_threads_manual");
-            listPreferenceMT.setProgress(manualSearchThreads);
+            // set number of download threads = number of cores
+            setNumberOfThreadsToBeEqualToNumberOfCores(8, "download_threads");
         }
         // Update the shared preferences with the current version code
         prefs.edit().putInt(PREF_VERSION_CODE_KEY, currentVersionCode).apply();
+    }
+
+    private void setNumberOfThreadsToBeEqualToNumberOfCores(int threadsMax, String preference) {
+        int threads;
+        if (Runtime.getRuntime().availableProcessors() <= threadsMax) {
+            threads = Runtime.getRuntime().availableProcessors();
+        } else {
+            threads = threadsMax;
+        }
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putString(preference, "" + threads).apply();
+
+        final SeekBarPreference2 tmpSeekbar = (SeekBarPreference2) getPreferenceManager().findPreference(preference);
+        tmpSeekbar.setProgress(threads);
     }
 
     @Override

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -148,7 +148,6 @@
     <string name="sort_number">Kapitelnummer (9&#8211;0)</string>
     <string name="sort_number_asc">Kapitelnummer</string>
     <string name="delete_comfirm">Wollen Sie wirklich das Kapitel löschen?</string>
-    <string name="new_chapters_found">Neue(s) Kapitel gefunden</string>
     <string name="storage_permission_denied">MiMangaNu benötigt zugriff auf den Speicher um korrekt funktionieren zu können</string>
     <string name="no_new_updates_found">Keine neuen Kapitel gefunden :(</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -56,7 +56,7 @@
     <string name="max_texture_subtitle">Tamaño de texturas, que se utilizará (0 para desactivar la aceleración de hardware)\n%s</string>
     <string name="opciones_descarga">Opciones de descarga</string>
     <string name="cantidad_descargas_title">Descargas simultaneas</string>
-    <string name="cantidad_descargas_subtitle">Cantidad de hilos: %s</string>
+    <string name="cantidad_descargas_subtitle">Cantidad de imágenes descargadas simultáneamente: %s</string>
     <string name="cantidad_errores_title">Tolerancia de error por capítulo</string>
     <string name="cantidad_errores_subtitle">Número tolerado de errores por capítulo: %s</string>
     <string name="cantidad_reintentos_title">Reintentos máximos por imagen</string>
@@ -151,7 +151,6 @@
     <string name="sort_number">Ordenar por número de capítulo</string>
     <string name="sort_number_asc">Ordenar por número de capítulo ASC</string>
     <string name="delete_comfirm">¿Estás seguro de borrar estos capítulos?</string>
-    <string name="new_chapters_found">nuevos capítulos encontrados</string>
     <string name="storage_permission_denied">Se requiere permiso de almacenamiento para MiMangaNu funcionen correctamente</string>
     <string name="no_new_updates_found">No se encontró nuevo capítulo :(</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -99,7 +99,7 @@
     <string name="notification_sound_subtitle">Al encotrar nuevos mangas.</string>
     <string name="notification_sound_title">Notificación sonora</string>
     <string name="see_later">Ver Despues</string>
-    <string name="update_message">Cambios 1.49 \n\t*Incluso más bug fixes\n\t*Establecer el número de hilos de búsqueda manual = núcleos de CPU en la primera carrera</string>
+    <string name="update_message">Cambios 1.49 \n\t*Incluso más bug fixes\n\t*Establecer el número de hilos de búsqueda manual y los hilos de descarga = núcleos de CPU en la primera carrera</string>
     <string name="download_image_again">Volver a bajar imagen</string>
     <string name="ui_settings">Configuración de UI</string>
     <string name="download_selection">Descargar seleccion</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -99,7 +99,7 @@
     <string name="notification_sound_subtitle">Al encotrar nuevos mangas.</string>
     <string name="notification_sound_title">Notificación sonora</string>
     <string name="see_later">Ver Despues</string>
-    <string name="update_message">Cambios 1.48 \n\t* Más bug fixes\n\t* Fixed senmanga y mymangaio</string>
+    <string name="update_message">Cambios 1.49 \n\t*Incluso más bug fixes\n\t*Establecer el número de hilos de búsqueda manual = núcleos de CPU en la primera carrera</string>
     <string name="download_image_again">Volver a bajar imagen</string>
     <string name="ui_settings">Configuración de UI</string>
     <string name="download_selection">Descargar seleccion</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -53,7 +53,7 @@
     <string name="max_texture_subtitle">Taille de texture, qui sera utilisé (0 pour désactiver l\'accélération)\n%s</string>
     <string name="opciones_descarga">"Paramètres de téléchargement"</string>
     <string name="cantidad_descargas_title">Téléchargements simultanés</string>
-    <string name="cantidad_descargas_subtitle">Nombre de téléchargements simultanés : %s</string>
+    <string name="cantidad_descargas_subtitle">Montant des images téléchargées en même temps: %s</string>
     <string name="cantidad_errores_title">Tolérance d\'erreur par chapitre</string>
     <string name="cantidad_errores_subtitle">Nombre d\'erreurs tolérées par chapitre : %s</string>
     <string name="cantidad_reintentos_title">Tentatives maximum par image</string>
@@ -142,7 +142,6 @@
     <string name="delete_comfirm">Etes-vous sûr de supprimer ces chapitres?</string>
     <string name="close">Fermer</string>
     <string name="retry">refaire</string>
-    <string name="new_chapters_found">nouveaux chapitres trouvés</string>
     <string name="storage_permission_denied">Stockage L\'autorisation est requise pour MiMangaNu fonctionnent correctement</string>
     <string name="no_new_updates_found">Aucun nouveau chapitre trouvé :(</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -56,7 +56,7 @@
     <string name="max_texture_subtitle">Dimensione della texture che sarà utilizzata (0 per disattivare l\'accelerazione hardware)\n%s</string>
     <string name="opciones_descarga">"Impostazioni di download"</string>
     <string name="cantidad_descargas_title">Download simultanei</string>
-    <string name="cantidad_descargas_subtitle">Numero di thread di scaricamento: %s</string>
+    <string name="cantidad_descargas_subtitle">Quantità di immagini scaricate contemporaneamente: %s</string>
     <string name="cantidad_errores_title">Tolleranza degli errori per capitolo</string>
     <string name="cantidad_errores_subtitle">Il numero tollerato di errori per capitolo: %s</string>
     <string name="cantidad_reintentos_title">Numero massimo di tentativi per immagine</string>
@@ -143,7 +143,6 @@
     <string name="delete_comfirm">Sei sicuro di voler eliminare questi capitoli?</string>
     <string name="close">vicino</string>
     <string name="retry">Riprova</string>
-    <string name="new_chapters_found">nuovi capitoli trovati</string>
     <string name="storage_permission_denied">Il permesso di archiviazione è necessario per MiMangaNu per funzionare correttamente</string>
     <string name="no_new_updates_found">Nessun nuovo capitolo trovato :(</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -23,7 +23,7 @@
     <string name="buscandonuevo">Поиск обновлений</string>
     <string name="buscarupdates">Искать обновления</string>
     <string name="busquedanores">Ничего не найдено</string>
-    <string name="cantidad_descargas_subtitle">Число скачиваемых глав: %s</string>
+    <string name="cantidad_descargas_subtitle">Количество изображений, загруженных одновременно: %s</string>
     <string name="cantidad_descargas_title">Слот скачивания</string>
     <string name="cantidad_errores_subtitle">допустимое число ошибок для главы: %s</string>
     <string name="cantidad_errores_title">Допустимое число ошибок</string>
@@ -142,7 +142,6 @@
     <string name="delete_comfirm">Вы уверены, чтобы удалить эти разделы?</string>
     <string name="close">близко</string>
     <string name="retry">Повторить попытку</string>
-    <string name="new_chapters_found">найдены новые главы</string>
     <string name="storage_permission_denied">Разрешение хранения требуется для MiMangaNu для правильной работы</string>
     <string name="no_new_updates_found">Ни одна новая глава не найдено :(</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,7 +122,7 @@
     <string name="read_next">Do you want to open the next chapter?</string>
     <string name="last_chapter">Currently this is the last chapter</string>
     <string name="genre">Genre</string>
-    <string name="update_message">Changes in v1.49:\n\t*Even more bug fixes.\n\t*set number of manual search threads = cpu cores at first run</string>
+    <string name="update_message">Changes in v1.49:\n\t*Even more bug fixes.\n\t*set number of manual search threads and download threads = cpu cores at first run</string>
     <string name="search_for_updates">Search for updates</string>
     <string name="update_thread_background_title">Update threads (Background)</string>
     <string name="update_threads_background_summary">Amount of update threads for background: %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,7 +122,7 @@
     <string name="read_next">Do you want to open the next chapter?</string>
     <string name="last_chapter">Currently this is the last chapter</string>
     <string name="genre">Genre</string>
-    <string name="update_message">Changes 1.48\n\t*More bug fixes.\n\t* Fixed senmanga and mymangaio.</string>
+    <string name="update_message">Changes in v1.49:\n\t*Even more bug fixes.\n\t*set number of manual search threads = cpu cores at first run</string>
     <string name="search_for_updates">Search for updates</string>
     <string name="update_thread_background_title">Update threads (Background)</string>
     <string name="update_threads_background_summary">Amount of update threads for background: %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,7 +151,6 @@
     <string name="sort_number">Sort by chapter number (9–0)</string>
     <string name="sort_number_asc">Sort by chapter number </string>
     <string name="delete_comfirm">Are you sure you want to delete these chapters?</string>
-    <string name="new_chapters_found">New chapter(s) found</string>
     <string name="storage_permission_denied">Storage Permission is required for MiMangaNu to work correctly</string>
     <string name="no_new_updates_found">No new chapters found :(</string>
 </resources>

--- a/app/src/main/res/xml/fragment_preferences.xml
+++ b/app/src/main/res/xml/fragment_preferences.xml
@@ -33,7 +33,7 @@
             android:key="update_threads_background"
             android:summary="@string/update_threads_background_summary"
             android:title="@string/update_thread_background_title"
-            app:val_max="7"
+            app:val_max="8"
             app:val_min="1" />
         <ar.rulosoft.custompref.SeekBarPreference2
             android:defaultValue="2"
@@ -41,7 +41,7 @@
             android:key="update_threads_manual"
             android:summary="@string/update_threads_manual_summary"
             android:title="@string/update_thread_manual_title"
-            app:val_max="7"
+            app:val_max="8"
             app:val_min="1" />
     </android.support.v7.preference.PreferenceCategory>
 


### PR DESCRIPTION
+ set number of manual search threads (and download threads) = number of cpu cores on first run (this is optimal and much better than setting an arbitrary number as default.)

+ update readme.md