### PR TITLE
Bug Fixes v2

### DIFF
--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityPagedReader.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityPagedReader.java
@@ -236,6 +236,9 @@ public class ActivityPagedReader extends AppCompatActivity
         mSeekBar.setBackgroundColor(reader_bg);
         mScrollSelect.setBackgroundColor(reader_bg);
 
+        if(pm.getBoolean("hide_sensitivity_scrollbar", false))
+            mScrollSelect.setVisibility(View.INVISIBLE);
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setNavigationBarColor(reader_bg);
@@ -428,7 +431,6 @@ public class ActivityPagedReader extends AppCompatActivity
     @Override
     protected void onResume() {
         super.onResume();
-        MainActivity.mContext = getApplicationContext();
     }
 
     @Override
@@ -730,8 +732,7 @@ public class ActivityPagedReader extends AppCompatActivity
                 if (previousChapter != null) {
                     seamlessChapterTransition = pm.getBoolean("seamless_chapter_transitions", false);
                     if (seamlessChapterTransition) {
-                        updateDBAndLoadChapter(previousChapter, Chapter.UNREAD, 0, ActivityReader.LoadMode.START);
-                        setCurrentItem(mChapter.getPagesRead() - 1);
+                        updateDBAndLoadChapter(previousChapter, Chapter.UNREAD, 0, ActivityReader.LoadMode.SAVED);
                         Util.getInstance().toast(getApplicationContext(), mChapter.getTitle(), 0);
                     }
                 }
@@ -743,7 +744,6 @@ public class ActivityPagedReader extends AppCompatActivity
                         Chapter tmpChapter = mChapter;
 
                         updateDBAndLoadChapter(nextChapter, Chapter.READ, mChapter.getPages(), ActivityReader.LoadMode.START);
-                        setCurrentItem(mChapter.getPagesRead() - 1);
                         Util.getInstance().toast(getApplicationContext(), mChapter.getTitle(), 0);
 
                         if (seamlessChapterTransitionDeleteRead) {
@@ -774,7 +774,6 @@ public class ActivityPagedReader extends AppCompatActivity
                         Chapter tmpChapter = mChapter;
 
                         updateDBAndLoadChapter(nextChapter, Chapter.READ, mChapter.getPages(), ActivityReader.LoadMode.START);
-                        setCurrentItem(mChapter.getPagesRead() - 1);
                         Util.getInstance().toast(getApplicationContext(), mChapter.getTitle(), 0);
 
                         if (seamlessChapterTransitionDeleteRead) {
@@ -789,8 +788,7 @@ public class ActivityPagedReader extends AppCompatActivity
                 if (previousChapter != null) {
                     seamlessChapterTransition = pm.getBoolean("seamless_chapter_transitions", false);
                     if (seamlessChapterTransition) {
-                        updateDBAndLoadChapter(previousChapter, Chapter.UNREAD, 0, ActivityReader.LoadMode.END);
-                        setCurrentItem(mChapter.getPagesRead() - 1);
+                        updateDBAndLoadChapter(previousChapter, Chapter.UNREAD, 0, ActivityReader.LoadMode.SAVED);
                         Util.getInstance().toast(getApplicationContext(), mChapter.getTitle(), 0);
                     }
                 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityReader.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityReader.java
@@ -141,6 +141,9 @@ public class ActivityReader extends AppCompatActivity implements StateChangeList
         mSeekBar.setBackgroundColor(reader_bg);
         mScrollSelect.setBackgroundColor(reader_bg);
 
+        if(pm.getBoolean("hide_sensitivity_scrollbar", false))
+            mScrollSelect.setVisibility(View.INVISIBLE);
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setNavigationBarColor(reader_bg);
@@ -455,7 +458,6 @@ public class ActivityReader extends AppCompatActivity implements StateChangeList
     @Override
     protected void onResume() {
         super.onResume();
-        MainActivity.mContext = getApplicationContext();
         DownloadPoolService.attachListener(this, mChapter.getId());
         mReader.seekPage(mChapter.getPagesRead() - 1);
     }
@@ -601,7 +603,7 @@ public class ActivityReader extends AppCompatActivity implements StateChangeList
         if (previousChapter != null) {
             boolean seamlessChapterTransition = pm.getBoolean("seamless_chapter_transitions", false);
             if (seamlessChapterTransition) {
-                updateDBAndLoadChapter(previousChapter, Chapter.UNREAD, 0, LoadMode.END);
+                updateDBAndLoadChapter(previousChapter, Chapter.UNREAD, 0, LoadMode.SAVED);
                 Util.getInstance().toast(getApplicationContext(), mChapter.getTitle(), 0);
             }
         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/DetailsFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/DetailsFragment.java
@@ -37,14 +37,15 @@ public class DetailsFragment extends Fragment {
     public static final String TITLE = "titulo_m";
     public static final String PATH = "path_m";
     private static final String TAG = "DetailFragment";
-    String title, path;
-    int id;
+    private String title, path;
+    private int id;
     private ImageLoader imageLoader;
     private ControlInfo data;
     private SwipeRefreshLayout swipeRefreshLayout;
     private ServerBase serverBase;
     private Manga manga;
-    private FloatingActionButton button_add;
+    private FloatingActionButton floatingActionButton_add;
+    private LoadDetailsTask loadDetailsTask = new LoadDetailsTask();
 
     @Nullable
     @Override
@@ -71,8 +72,8 @@ public class DetailsFragment extends Fragment {
         if (mActBar != null) {
             mActBar.setDisplayHomeAsUpEnabled(true);
         }
-        button_add = (FloatingActionButton) getView().findViewById(R.id.floatingActionButton_add);
-        button_add.setOnClickListener(new OnClickListener() {
+        floatingActionButton_add = (FloatingActionButton) getView().findViewById(R.id.floatingActionButton_add);
+        floatingActionButton_add.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 List<Manga> mangas = Database.getMangas(getContext(), null, true);
@@ -84,10 +85,10 @@ public class DetailsFragment extends Fragment {
                 if (!onDb) {
                     new AddMangaTask().execute(manga);
                     AnimatorSet set = new AnimatorSet();
-                    ObjectAnimator anim1 = ObjectAnimator.ofFloat(button_add, "alpha", 1.0f, 0.0f);
+                    ObjectAnimator anim1 = ObjectAnimator.ofFloat(floatingActionButton_add, "alpha", 1.0f, 0.0f);
                     anim1.setDuration(0);
                     DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
-                    ObjectAnimator anim2 = ObjectAnimator.ofFloat(button_add, "y", displayMetrics.heightPixels);
+                    ObjectAnimator anim2 = ObjectAnimator.ofFloat(floatingActionButton_add, "y", displayMetrics.heightPixels);
                     anim2.setDuration(500);
                     set.playSequentially(anim2, anim1);
                     set.start();
@@ -96,24 +97,24 @@ public class DetailsFragment extends Fragment {
                 }
             }
         });
+        floatingActionButton_add.setBackgroundTintList(ColorStateList.valueOf(MainActivity.colors[1]));
+        swipeRefreshLayout.setColorSchemeColors(MainActivity.colors[0], MainActivity.colors[1]);
+        data.setColor(MainActivity.darkTheme, MainActivity.colors[0]);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Window window = getActivity().getWindow();
+            window.setNavigationBarColor(MainActivity.colors[0]);
+            window.setStatusBarColor(MainActivity.colors[4]);
+        }
         if (getActivity() != null) {
-            button_add.setBackgroundTintList(ColorStateList.valueOf(((MainActivity) getActivity()).colors[1]));
-            swipeRefreshLayout.setColorSchemeColors(((MainActivity) getActivity()).colors[0], ((MainActivity) getActivity()).colors[1]);
-            data.setColor(((MainActivity) getActivity()).darkTheme, ((MainActivity) getActivity()).colors[0]);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                Window window = getActivity().getWindow();
-                window.setNavigationBarColor(((MainActivity) getActivity()).colors[0]);
-                window.setStatusBarColor(((MainActivity) getActivity()).colors[4]);
-            }
-            ((MainActivity)getActivity()).setTitle(getResources().getString(R.string.datosde) + " " + title);
+            ((MainActivity) getActivity()).setTitle(getResources().getString(R.string.datosde) + " " + title);
         }
         manga = new Manga(id, title, path, false);
         serverBase = ServerBase.getServer(id);
-        imageLoader = new ImageLoader(this.getActivity());
+        imageLoader = new ImageLoader(getContext());
         swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
-                new LoadDetailsTask().execute();
+                loadDetailsTask = (LoadDetailsTask) new LoadDetailsTask().execute();
             }
         });
         swipeRefreshLayout.post(new Runnable() {
@@ -122,13 +123,19 @@ public class DetailsFragment extends Fragment {
                 swipeRefreshLayout.setRefreshing(true);
             }
         });
-        new LoadDetailsTask().execute();
+        loadDetailsTask = (LoadDetailsTask) new LoadDetailsTask().execute();
     }
 
     @Override
     public void onResume() {
         super.onResume();
         ((MainActivity)getActivity()).enableHomeButton(true);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        loadDetailsTask.cancel(true);
     }
 
     @Override
@@ -189,13 +196,13 @@ public class DetailsFragment extends Fragment {
                         Toast.makeText(getActivity(), error, Toast.LENGTH_LONG).show();
                     } else {
                         AnimatorSet set = new AnimatorSet();
-                        ObjectAnimator anim1 = ObjectAnimator.ofFloat(button_add, "alpha", 0.0f, 1.0f);
+                        ObjectAnimator anim1 = ObjectAnimator.ofFloat(floatingActionButton_add, "alpha", 0.0f, 1.0f);
                         anim1.setDuration(0);
-                        float y = button_add.getY();
+                        float y = floatingActionButton_add.getY();
                         DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
-                        ObjectAnimator anim2 = ObjectAnimator.ofFloat(button_add, "y", displayMetrics.heightPixels);
+                        ObjectAnimator anim2 = ObjectAnimator.ofFloat(floatingActionButton_add, "y", displayMetrics.heightPixels);
                         anim2.setDuration(0);
-                        ObjectAnimator anim3 = ObjectAnimator.ofFloat(button_add, "y", y);
+                        ObjectAnimator anim3 = ObjectAnimator.ofFloat(floatingActionButton_add, "y", y);
                         anim3.setInterpolator(new AccelerateDecelerateInterpolator());
                         anim3.setDuration(500);
                         set.playSequentially(anim2, anim1, anim3);

--- a/app/src/main/java/ar/rulosoft/mimanganu/DownloadsFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/DownloadsFragment.java
@@ -30,7 +30,7 @@ public class DownloadsFragment extends Fragment {
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        darkTheme = ((MainActivity)getActivity()).darkTheme;
+        darkTheme = MainActivity.darkTheme;
         list = (ListView) getView().findViewById(R.id.action_view_download);
     }
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/LicenseFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/LicenseFragment.java
@@ -31,7 +31,7 @@ public class LicenseFragment extends Fragment {
         lic = new TextView(getActivity());
         lic.setTextAppearance(getActivity(), android.R.style.TextAppearance_Medium);
         lic.setPadding(10, 10, 10, 10);
-        if (!((MainActivity)getActivity()).darkTheme) {
+        if (!MainActivity.darkTheme) {
             lic.setTextColor(getResources().getColor(black));
         }
         ScrollView newScroll = new ScrollView(getActivity());

--- a/app/src/main/java/ar/rulosoft/mimanganu/MainActivity.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MainActivity.java
@@ -2,7 +2,6 @@ package ar.rulosoft.mimanganu;
 
 import android.Manifest;
 import android.app.AlertDialog;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -28,13 +27,14 @@ import ar.rulosoft.mimanganu.utils.ThemeColors;
 import ar.rulosoft.mimanganu.utils.Util;
 
 public class MainActivity extends AppCompatActivity {
-    public static Context mContext;
-    public int[] colors;
+    public static int[] colors;
+    public static boolean darkTheme;
+    public static SharedPreferences pm;
+    public static MainFragment.UpdateListTask updateListTask;
+    public static boolean isConnected = true;
     public ActionBar mActBar;
-    boolean darkTheme;
     OnBackListener backListener;
     OnKeyUpListener keyUpListener;
-    public static SharedPreferences pm;
     private final int WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST_CODE = 0;
 
     @Override
@@ -68,6 +68,9 @@ public class MainActivity extends AppCompatActivity {
             MangaFragment mangaFragment = new MangaFragment();
             mangaFragment.setArguments(bundle);
             replaceFragment(mangaFragment, "MangaFragment");
+        } else if (mangaIdFromNotification == -1) {
+            if(updateListTask != null)
+                updateListTask.cancel(true);
         }
     }
 
@@ -127,16 +130,15 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        mContext = getApplicationContext();
         if (darkTheme != pm.getBoolean("dark_theme", false)) {
             Util.getInstance().restartApp(getApplicationContext());
         }
-        colors = ThemeColors.getColors(pm, getApplicationContext());
+        colors = ThemeColors.getColors(pm);
         setColorToBars();
     }
 
     public void setColorToBars() {
-        colors = ThemeColors.getColors(pm, getApplicationContext());
+        colors = ThemeColors.getColors(pm);
         mActBar = getSupportActionBar();
         if (mActBar != null) mActBar.setBackgroundDrawable(new ColorDrawable(colors[0]));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
@@ -574,7 +574,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
         protected void onProgressUpdate(Integer... values) {
             // Update progress
             if (context != null) {
-                Util.getInstance().changeNotification(mList.size(), ++numNow, mNotifyID, context.getResources().getString(R.string.searching_for_updates), numNow + "/" + mList.size() + " - " +
+                Util.getInstance().changeSearchingForUpdatesNotification(mList.size(), ++numNow, mNotifyID, context.getResources().getString(R.string.searching_for_updates), numNow + "/" + mList.size() + " - " +
                         mList.get(values[0]).getTitle(), true);
             }
             super.onProgressUpdate(values);
@@ -646,7 +646,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
             if (context != null) {
                 if (result > 0) {
                     if (!pm.getBoolean("show_notification_per_new_chapter", false))
-                        Util.getInstance().changeNotification(0, 0, mNotifyID, context.getResources().getString(R.string.update_complete), String.format(context.getResources().getString(R.string.mgs_update_found), result), false);
+                        Util.getInstance().changeSearchingForUpdatesNotification(0, 0, mNotifyID, context.getResources().getString(R.string.update_complete), String.format(context.getResources().getString(R.string.mgs_update_found), result), false);
                     else
                         Util.getInstance().cancelNotification(mNotifyID);
                     setListManga(true);

--- a/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
@@ -70,7 +70,6 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
     private GridView grid;
     private MisMangasAdapter adapter;
     private SwipeRefreshLayout swipeReLayout;
-    private UpdateListTask updateListTask;
     private int mNotifyID = 1246502;
     private boolean returnToMangaList = false;
 
@@ -109,6 +108,8 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
         super.onPause();
         if (is_server_list_open)
             is_server_list_open = false;
+        if(swipeReLayout != null)
+            swipeReLayout.clearAnimation();
     }
 
     @Override
@@ -117,16 +118,16 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
         mViewPager.setAdapter(mSectionsPagerAdapter);
         mViewPager.setPageTransformer(false, new MoreMangasPageTransformer());
         MainActivity activity = (MainActivity) getActivity();
-        activity.colors = ThemeColors.getColors(pm, getActivity());
+        MainActivity.colors = ThemeColors.getColors(pm);
         activity.setColorToBars();
-        if (activity.darkTheme != pm.getBoolean("dark_theme", false)) {
+        if (MainActivity.darkTheme != pm.getBoolean("dark_theme", false)) {
             Util.getInstance().restartApp(getContext());
         }
         activity.enableHomeButton(false);
         activity.setTitle(getString(R.string.app_name));
         activity.backListener = this;
         activity.keyUpListener = this;
-        floatingActionButton_add.setBackgroundTintList(ColorStateList.valueOf(activity.colors[1]));
+        floatingActionButton_add.setBackgroundTintList(ColorStateList.valueOf(MainActivity.colors[1]));
         if (!is_server_list_open && getView() != null) {
             ObjectAnimator anim =
                     ObjectAnimator.ofFloat(getView().findViewById(R.id.floatingActionButton_add), "rotation", 315.0f, 360.0f);
@@ -355,7 +356,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
                     break;
             }
             if (adapter == null || sort_val < 2 || mangaList.size() > adapter.getCount() || force) {
-                adapter = new MisMangasAdapter(getActivity(), mangaList, ((MainActivity) getActivity()).darkTheme);
+                adapter = new MisMangasAdapter(getActivity(), mangaList, MainActivity.darkTheme);
                 grid.setAdapter(adapter);
             }
         } else {
@@ -404,18 +405,17 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
     public ViewGroup getMMView(ViewGroup container) {
         LayoutInflater inflater = LayoutInflater.from(getActivity());
         ViewGroup viewGroup = (ViewGroup) inflater.inflate(R.layout.fragment_mis_mangas, container, false);
-        MainActivity mMainActivity = (MainActivity) getActivity();
         grid = (GridView) viewGroup.findViewById(R.id.grilla_mis_mangas);
         swipeReLayout = (SwipeRefreshLayout) viewGroup.findViewById(R.id.str);
-        swipeReLayout.setColorSchemeColors(mMainActivity.colors[0],mMainActivity.colors[1]);
+        swipeReLayout.setColorSchemeColors(MainActivity.colors[0], MainActivity.colors[1]);
         swipeReLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
                 switch (NetworkUtilsAndReciever.getConnectionStatus(getActivity())){
                     case CONNECTED:
-                        if (updateListTask == null || updateListTask.getStatus() == AsyncTask.Status.FINISHED) {
-                            updateListTask = new UpdateListTask(getActivity());
-                            updateListTask.execute();
+                        if (MainActivity.updateListTask == null || MainActivity.updateListTask.getStatus() == AsyncTask.Status.FINISHED) {
+                            MainActivity.updateListTask = new UpdateListTask(getActivity());
+                            MainActivity.updateListTask.execute();
                         }
                         break;
                     case NO_INET_CONNECTED:
@@ -440,7 +440,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
         else if (columnas > 6)
             columnas = 6;
         grid.setNumColumns(columnas);
-        if (updateListTask != null && updateListTask.getStatus() == AsyncTask.Status.RUNNING) {
+        if (MainActivity.updateListTask != null && MainActivity.updateListTask.getStatus() == AsyncTask.Status.RUNNING) {
             swipeReLayout.post(new Runnable() {
                 @Override
                 public void run() {
@@ -550,7 +550,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
     }
 
     public class UpdateListTask extends AsyncTask<Void, Integer, Integer> {
-        final ArrayList<Manga> mList = Database.getMangasForUpdates(getContext());
+        ArrayList<Manga> mangaList = Database.getMangasForUpdates(getContext());
         int threads = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(getActivity()).getString("update_threads_manual", "2"));
         int ticket = threads;
         int result = 0;
@@ -559,6 +559,8 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
 
         public UpdateListTask(Context context) {
             this.context = context;
+            if (pm.getBoolean("include_finished_manga", false))
+                mangaList = Database.getMangas(getContext(), null, true);
         }
 
         @Override
@@ -572,10 +574,9 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
 
         @Override
         protected void onProgressUpdate(Integer... values) {
-            // Update progress
             if (context != null) {
-                Util.getInstance().changeSearchingForUpdatesNotification(mList.size(), ++numNow, mNotifyID, context.getResources().getString(R.string.searching_for_updates), numNow + "/" + mList.size() + " - " +
-                        mList.get(values[0]).getTitle(), true);
+                Util.getInstance().changeSearchingForUpdatesNotification(context, mangaList.size(), ++numNow, mNotifyID, context.getResources().getString(R.string.searching_for_updates), numNow + "/" + mangaList.size() + " - " +
+                        mangaList.get(values[0]).getTitle(), true);
             }
             super.onProgressUpdate(values);
         }
@@ -584,10 +585,10 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
         protected Integer doInBackground(Void... params) {
             if (context != null) {
                 ticket = threads;
-                // Starting searching for new chapters
-                for (int idx = 0; idx < mList.size(); idx++) {
+                for (int idx = 0; idx < mangaList.size(); idx++) {
                     if (NetworkUtilsAndReciever.isWifiConnected(context) || NetworkUtilsAndReciever.isMobileConnected(context)) {
                         final int idxNow = idx;
+
                         // If there is no ticket, sleep for 1 second and ask again
                         while (ticket < 1) {
                             try {
@@ -597,22 +598,26 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
                             }
                         }
                         ticket--;
-                        // If ticked were passed, create new request
+
+                        // If tickets were passed, create new requests
                         new Thread(new Runnable() {
                             @Override
                             public void run() {
-                                Manga mManga = mList.get(idxNow);
+                                Manga mManga = mangaList.get(idxNow);
                                 ServerBase serverBase = ServerBase.getServer(mManga.getServerId());
                                 publishProgress(idxNow);
                                 try {
-                                    serverBase.loadChapters(mManga, false);
-                                    int diff = serverBase.searchForNewChapters(mManga.getId(), getActivity());
-                                    result += diff;
+                                    if (!isCancelled()) {
+                                        serverBase.loadChapters(mManga, false);
+                                        int diff = serverBase.searchForNewChapters(mManga.getId(), getActivity());
+                                        result += diff;
+                                    }
                                 } catch (Exception e) {
                                     Log.e(TAG, "Update server failure", e);
                                 } finally {
                                     ticket++;
                                 }
+
                             }
                         }).start();
 
@@ -628,6 +633,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
                         break;
                     }
                 }
+
                 // After finishing the loop, wait for all threads to finish their task before ending
                 while (ticket < threads) {
                     try {
@@ -637,6 +643,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
                     }
                 }
             }
+
             return result;
         }
 
@@ -646,7 +653,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
             if (context != null) {
                 if (result > 0) {
                     if (!pm.getBoolean("show_notification_per_new_chapter", false))
-                        Util.getInstance().changeSearchingForUpdatesNotification(0, 0, mNotifyID, context.getResources().getString(R.string.update_complete), String.format(context.getResources().getString(R.string.mgs_update_found), result), false);
+                        Util.getInstance().changeSearchingForUpdatesNotification(context, 0, 0, mNotifyID, context.getResources().getString(R.string.update_complete), String.format(context.getResources().getString(R.string.mgs_update_found), result), false);
                     else
                         Util.getInstance().cancelNotification(mNotifyID);
                     setListManga(true);
@@ -659,6 +666,13 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
             } else {
                 Util.getInstance().cancelNotification(mNotifyID);
             }
+        }
+
+        @Override
+        protected void onCancelled() {
+            if (context != null)
+                Util.getInstance().toast(context, getString(R.string.update_search_cancelled));
+            swipeReLayout.setRefreshing(false);
         }
     }
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/MangaFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MangaFragment.java
@@ -1,7 +1,9 @@
 package ar.rulosoft.mimanganu;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -51,9 +53,9 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
     public static final String CHAPTERS_ORDER = "chapters_order";
     public static final String CHAPTER_ID = "cap_id";
     private static final String TAG = "MangaFragment";
-    public SwipeRefreshLayout mSwipeRefreshLayout;
+    public SwipeRefreshLayout swipeReLayout;
     public Manga mManga;
-    SearchForNewsChapters searchTask = new SearchForNewsChapters();
+    private SearchForNewChapters searchForNewChapters = new SearchForNewChapters();
     private Direction mDirection;
     private ChapterAdapter mChapterAdapter;
     private SharedPreferences pm;
@@ -64,7 +66,8 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
     private int chapters_order; // 0 = db | 1 = chapter number | 2 = chapter number asc | 3 = title | 4 = title asc
     private Menu menu;
     private ControlInfoNoScroll mInfo;
-    ServerBase mServerBase;
+    private ServerBase mServerBase;
+    private Activity activity;
 
     @Nullable
     @Override
@@ -90,27 +93,27 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         }
         if (getView() != null) {
             mListView = (ListView) getView().findViewById(R.id.lista);
-            mSwipeRefreshLayout = (SwipeRefreshLayout) getView().findViewById(R.id.str);
+            swipeReLayout = (SwipeRefreshLayout) getView().findViewById(R.id.str);
         }
         mImageLoader = new ImageLoader(getActivity());
-        int[] colors = ThemeColors.getColors(pm, getActivity());
-        mSwipeRefreshLayout.setColorSchemeColors(colors[0], colors[1]);
+        int[] colors = ThemeColors.getColors(pm);
+        swipeReLayout.setColorSchemeColors(colors[0], colors[1]);
         if (savedInstanceState != null) {
-            if (searchTask.getStatus() == AsyncTask.Status.RUNNING) {
-                mSwipeRefreshLayout.post(new Runnable() {
+            if (searchForNewChapters.getStatus() == AsyncTask.Status.RUNNING) {
+                swipeReLayout.post(new Runnable() {
                     @Override
                     public void run() {
-                        mSwipeRefreshLayout.setRefreshing(true);
+                        swipeReLayout.setRefreshing(true);
                     }
                 });
             }
         }
-        mSwipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+        swipeReLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
-                if ((searchTask.getStatus() != AsyncTask.Status.RUNNING)) {
-                    searchTask = new SearchForNewsChapters();
-                    searchTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                if ((searchForNewChapters.getStatus() != AsyncTask.Status.RUNNING)) {
+                    searchForNewChapters = new SearchForNewChapters();
+                    searchForNewChapters.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                 }
             }
         });
@@ -118,8 +121,8 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         mListView.setDividerHeight(1);
         mInfo = new ControlInfoNoScroll(getActivity());
         mListView.addHeaderView(mInfo);
-        mInfo.setColor(((MainActivity) (getActivity())).darkTheme, colors[0]);
-        ChapterAdapter.setColor(((MainActivity) (getActivity())).darkTheme, colors[1], colors[0]);
+        mInfo.setColor(MainActivity.darkTheme, colors[0]);
+        ChapterAdapter.setColor(MainActivity.darkTheme, colors[1], colors[0]);
         mListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
@@ -282,7 +285,8 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
             fvi = mListView.getFirstVisiblePosition();
             mChapterAdapter.replaceData(chapters);
         } else {
-            mChapterAdapter = new ChapterAdapter(getActivity(), chapters,!(mServerBase instanceof FromFolder));
+            if(activity != null)
+                mChapterAdapter = new ChapterAdapter(activity, chapters, !(mServerBase instanceof FromFolder));
         }
         if (mListView != null) {
             mListView.setAdapter(mChapterAdapter);
@@ -296,6 +300,8 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         int first = mListView.getFirstVisiblePosition();
         Database.updateMangaLastIndex(getActivity(), mManga.getId(), first);
         super.onPause();
+        if(swipeReLayout != null)
+            swipeReLayout.clearAnimation();
     }
 
     @Override
@@ -460,6 +466,21 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
     }
 
     @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof Activity) {
+            activity = (Activity) context;
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        activity = null;
+        searchForNewChapters.cancel(true);
+    }
+
+    @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.menu_manga, menu);
         mMenuItemReaderSense = menu.findItem(R.id.action_sentido);
@@ -562,9 +583,9 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         }
     }
 
-    public class SearchForNewsChapters extends AsyncTask<Void, Void, Integer> {
+    public class SearchForNewChapters extends AsyncTask<Void, Void, Integer> {
         boolean running = false;
-        SearchForNewsChapters actual = null;
+        SearchForNewChapters actual = null;
         int mangaId = 0;
         String msg;
         String orgMsg;
@@ -603,7 +624,7 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
             Manga manga = Database.getManga(getActivity(), mangaId);
             loadInfo(manga);
             new SortAndLoadChapters().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-            mSwipeRefreshLayout.setRefreshing(false);
+            swipeReLayout.setRefreshing(false);
             if(isAdded()) {
                 getActivity().setTitle(orgMsg);
             }

--- a/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
@@ -248,7 +248,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
                 Preference resetServerListToDefaults = getPreferenceManager().findPreference("reset_server_list_to_defaults");
                 resetServerListToDefaults.setEnabled(false);
                 prefs.edit().putString("unused_servers", "").apply();
-
                 return true;
             }
         });
@@ -280,20 +279,17 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
         } else if (savedVersionCode == DOESNT_EXIST || currentVersionCode > savedVersionCode) {
             // This is a new install or upgrade
 
-            // set number of manual search threads = number of cores
             setNumberOfThreadsToBeEqualToNumberOfCores(4, "update_threads_manual");
-
-            // set number of download threads = number of cores
             setNumberOfThreadsToBeEqualToNumberOfCores(4, "download_threads");
+            setNumberOfThreadsToBeEqualToNumberOfCores(4, "update_threads_background");
         }
-        // Update the shared preferences with the current version code
         prefs.edit().putInt(PREF_VERSION_CODE_KEY, currentVersionCode).apply();
     }
 
     private void setNumberOfThreadsToBeEqualToNumberOfCores(int threadsMax, String preference) {
-        int threads;
-        if (Runtime.getRuntime().availableProcessors() <= threadsMax) {
-            threads = Runtime.getRuntime().availableProcessors();
+        int threads, availableProcessors = Runtime.getRuntime().availableProcessors();
+        if (availableProcessors <= threadsMax) {
+            threads = availableProcessors;
         } else {
             threads = threadsMax;
         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/SearchResultsFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/SearchResultsFragment.java
@@ -26,7 +26,7 @@ public class SearchResultsFragment extends Fragment {
     private int serverId;
     private ProgressBar loading;
     private ListView list;
-    private PerformSearchTask performSearchTask;
+    private PerformSearchTask performSearchTask = new PerformSearchTask();
     private boolean searchPerformed;
     private ArrayList<Manga> mangasFromSearch = new ArrayList<>();
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/SearchResultsFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/SearchResultsFragment.java
@@ -27,6 +27,8 @@ public class SearchResultsFragment extends Fragment {
     private ProgressBar loading;
     private ListView list;
     private PerformSearchTask performSearchTask;
+    private boolean searchPerformed;
+    private ArrayList<Manga> mangasFromSearch = new ArrayList<>();
 
     @Nullable
     @Override
@@ -54,9 +56,14 @@ public class SearchResultsFragment extends Fragment {
                 DetailsFragment detailsFragment = new DetailsFragment();
                 detailsFragment.setArguments(bundle);
                 ((MainActivity) getActivity()).replaceFragment(detailsFragment, "DetailsFragment");
+                searchPerformed = true;
             }
         });
-        performSearchTask = (PerformSearchTask) new PerformSearchTask().execute();
+        if (searchPerformed) {
+            if (list != null)
+                list.setAdapter(new ArrayAdapter<>(getActivity(), android.R.layout.simple_list_item_1, mangasFromSearch));
+        } else
+            performSearchTask = (PerformSearchTask) new PerformSearchTask().execute();
     }
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -76,12 +83,15 @@ public class SearchResultsFragment extends Fragment {
         super.onResume();
         ServerBase serverBase = ServerBase.getServer(serverId);
         ((MainActivity) getActivity()).setTitle(getResources().getString(R.string.search_result, search_term) + " " + serverBase.getServerName());
+        if(searchPerformed)
+            loading.setVisibility(ProgressBar.INVISIBLE);
     }
 
     @Override
     public void onDetach() {
         super.onDetach();
         performSearchTask.cancel(true);
+        mangasFromSearch.clear();
     }
 
     public class PerformSearchTask extends AsyncTask<Void, Void, ArrayList<Manga>> {
@@ -114,6 +124,9 @@ public class SearchResultsFragment extends Fragment {
                     if (error.length() < 2) {
                         if (result != null && !result.isEmpty() && list != null) {
                             list.setAdapter(new ArrayAdapter<>(getActivity(), android.R.layout.simple_list_item_1, result));
+                            if(!mangasFromSearch.isEmpty())
+                                mangasFromSearch.clear();
+                            mangasFromSearch.addAll(result);
                         } else if (result == null || result.isEmpty()) {
                             Toast.makeText(getActivity(), getResources().getString(R.string.busquedanores), Toast.LENGTH_LONG).show();
                         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/ServerFilteredNavigationFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ServerFilteredNavigationFragment.java
@@ -71,7 +71,7 @@ public class ServerFilteredNavigationFragment extends Fragment implements OnLast
     public void onActivityCreated(Bundle savedState) {
         super.onActivityCreated(savedState);
         SharedPreferences pm = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        int[] colors = ThemeColors.getColors(pm, getActivity());
+        int[] colors = ThemeColors.getColors(pm);
         ActionBar mActBar = getActivity().getActionBar();
         if (mActBar != null) {
             mActBar.setTitle(getResources()
@@ -257,9 +257,9 @@ public class ServerFilteredNavigationFragment extends Fragment implements OnLast
                     if(isAdded()) {
                         if (mAdapter == null) {
                             if (serverBase.getFilteredType() == ServerBase.FilteredType.VISUAL) {
-                                mAdapter = new MangasRecAdapter(result, getActivity(), ((MainActivity) getActivity()).darkTheme);
+                                mAdapter = new MangasRecAdapter(result, getActivity(), MainActivity.darkTheme);
                             } else {
-                                mAdapter = new MangasRecAdapterText(result, getActivity(), ((MainActivity) getActivity()).darkTheme);
+                                mAdapter = new MangasRecAdapterText(result, getActivity(), MainActivity.darkTheme);
                             }
                             mAdapter.setLastItemListener(ServerFilteredNavigationFragment.this);
                             mAdapter.setMangaClickListener(ServerFilteredNavigationFragment.this);

--- a/app/src/main/java/ar/rulosoft/mimanganu/ServerListFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ServerListFragment.java
@@ -145,7 +145,7 @@ public class ServerListFragment extends Fragment {
         @Override
         protected void onPostExecute(List<Manga> result) {
             if (list != null && result != null && !result.isEmpty() && isAdded()) {
-                adapter = new MangaAdapter(getContext(), result, MainActivity.darkTheme);
+                adapter = new MangaAdapter(getContext(), result, ((MainActivity) getActivity()).darkTheme);
                 list.setAdapter(adapter);
             }
             if (error != null && error.length() > 2 && isAdded()) {

--- a/app/src/main/java/ar/rulosoft/mimanganu/ServerListFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ServerListFragment.java
@@ -145,7 +145,7 @@ public class ServerListFragment extends Fragment {
         @Override
         protected void onPostExecute(List<Manga> result) {
             if (list != null && result != null && !result.isEmpty() && isAdded()) {
-                adapter = new MangaAdapter(getContext(), result, ((MainActivity) getActivity()).darkTheme);
+                adapter = new MangaAdapter(getContext(), result, MainActivity.darkTheme);
                 list.setAdapter(adapter);
             }
             if (error != null && error.length() > 2 && isAdded()) {

--- a/app/src/main/java/ar/rulosoft/mimanganu/adapters/ChapterAdapter.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/adapters/ChapterAdapter.java
@@ -41,12 +41,12 @@ public class ChapterAdapter extends ArrayAdapter<Chapter> {
     private ArrayList<Chapter> chapters;
     private boolean can_download;
 
-    public ChapterAdapter(Activity context, ArrayList<Chapter> items, boolean can_download) {
-        super(context, listItem);
-        this.activity = context;
+    public ChapterAdapter(Activity activity, ArrayList<Chapter> items, boolean can_download) {
+        super(activity, listItem);
+        this.activity = activity;
         this.chapters = items;
         this.can_download = can_download;
-        li = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        li = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
     }
 
     public static void setColor(boolean dark_theme, int colorSelected, int colorReading) {

--- a/app/src/main/java/ar/rulosoft/mimanganu/adapters/MisMangasAdapter.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/adapters/MisMangasAdapter.java
@@ -21,17 +21,17 @@ import ar.rulosoft.mimanganu.servers.ServerBase;
 public class MisMangasAdapter extends ArrayAdapter<Manga> {
 
     private static int resource = R.layout.control_tapa_manga;
-    Activity c;
+    Activity activity;
     private ImageLoader imageLoader;
     private boolean darkTheme = false;
     private int darkBackground;
 
-    public MisMangasAdapter(Activity context, List<Manga> objects, boolean darkTheme) {
-        super(context, resource, objects);
+    public MisMangasAdapter(Activity activity, List<Manga> objects, boolean darkTheme) {
+        super(activity, resource, objects);
         this.darkTheme = darkTheme;
-        this.darkBackground = context.getResources().getColor(R.color.background_floating_material_dark);
-        c = context;
-        imageLoader = new ImageLoader(context);
+        this.darkBackground = activity.getResources().getColor(R.color.background_floating_material_dark);
+        this.activity = activity;
+        imageLoader = new ImageLoader(activity);
     }
 
     @Override
@@ -39,7 +39,7 @@ public class MisMangasAdapter extends ArrayAdapter<Manga> {
         View item = convertView;
         ViewHolder holder;
         if (item == null) {
-            LayoutInflater inflater = c.getLayoutInflater();
+            LayoutInflater inflater = activity.getLayoutInflater();
             item = inflater.inflate(resource, null);
             holder = new ViewHolder(item);
             item.setTag(holder);

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/Chapter.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/Chapter.java
@@ -139,10 +139,10 @@ public class Chapter {
         deleteImages(context, manga, s);
     }
 
-    private void deleteImages(Context context, Manga manga, ServerBase s) {
+    private void deleteImages(Context context, Manga manga, ServerBase serverBase) {
         String path;
-        if (!(s instanceof FromFolder))
-            path = DownloadPoolService.generateBasePath(s, manga, this, context);
+        if (!(serverBase instanceof FromFolder))
+            path = DownloadPoolService.generateBasePath(serverBase, manga, this, context);
         else
             path = getPath();
         //Util.getInstance().deleteRecursive(new File(path));

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/Database.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/Database.java
@@ -310,17 +310,16 @@ public class Database extends SQLiteOpenHelper {
         return mangas;
     }
 
-    public static Manga getFullManga(Context c, int mangaID) {
-        return getFullManga(c, mangaID, false);
+    public static Manga getFullManga(Context context, int mangaID) {
+        return getFullManga(context, mangaID, false);
     }
 
-    public static Manga getFullManga(Context c, int mangaID, boolean asc) {
+    public static Manga getFullManga(Context context, int mangaID, boolean asc) {
         Manga manga = null;
         try {
-            Manga m = getMangasCondition(c, COL_ID + "=" + mangaID, null, false).get(0);
-            m.setChapters(getChapters(c, mangaID, "1", asc));
-            manga = m;
-        } catch (Exception e) {
+            manga = getMangasCondition(context, COL_ID + "=" + mangaID, null, false).get(0);
+            manga.setChapters(getChapters(context, mangaID, "1", asc));
+        } catch (Exception ignore) {
             // ignore this
         }
         return manga;

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/readers/R2LReader.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/readers/R2LReader.java
@@ -1,9 +1,6 @@
 package ar.rulosoft.mimanganu.componentes.readers;
 
-import android.animation.Animator;
-import android.animation.ValueAnimator;
 import android.content.Context;
-import android.graphics.Canvas;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -398,7 +398,7 @@ public abstract class ServerBase {
                 Intent intent = new Intent(context, MainActivity.class);
                 intent.putExtra("manga_id", simpleList.get(i).getMangaID());
                 intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                Util.getInstance().createSimpleNotification(context, false, (int) System.currentTimeMillis(), intent, context.getResources().getString(R.string.new_chapter, manga.getTitle()), simpleList.get(i).getTitle());
+                Util.getInstance().createNotification(context, false, (int) System.currentTimeMillis(), intent, context.getResources().getString(R.string.new_chapter, manga.getTitle()), simpleList.get(i).getTitle());
             }
             return null;
         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/services/AlarmReceiver.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/services/AlarmReceiver.java
@@ -50,8 +50,6 @@ public class AlarmReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (context != null)
-            MainActivity.mContext = context;
         try {
             if (NetworkUtilsAndReciever.isConnected(context)) {
                 SearchUpdates searchUpdates = new SearchUpdates();

--- a/app/src/main/java/ar/rulosoft/mimanganu/services/ChapterDownload.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/services/ChapterDownload.java
@@ -49,6 +49,7 @@ public class ChapterDownload implements StateChangeListener {
                         }
                     } else {
                         Log.e("ChapterDownload", "i is too large! pagesStatus.length: " + pagesStatus.length + " i: " + i);
+                        break;
                     }
                 }
             }

--- a/app/src/main/java/ar/rulosoft/mimanganu/services/DownloadPoolService.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/services/DownloadPoolService.java
@@ -8,6 +8,7 @@ import android.content.SharedPreferences;
 import android.os.Environment;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import android.widget.Toast;
 
 import java.io.File;
@@ -32,7 +33,6 @@ public class DownloadPoolService extends Service implements StateChangeListener 
             58, 42, 63, 92, 47
     };
     public static int SLOTS = 2;
-    public static Context mContext;
     public static DownloadPoolService actual = null;
     public static ArrayList<ChapterDownload> chapterDownloads = new ArrayList<>();
     public static DownloadsChangesListener mDownloadsChangesListener;
@@ -46,6 +46,9 @@ public class DownloadPoolService extends Service implements StateChangeListener 
     public int slots = SLOTS;
 
     public static void addChapterDownloadPool(Activity activity, Chapter chapter, boolean lectura) throws Exception{
+        if(activity == null)
+            Log.d("DPS","null");
+
         if (!chapter.isDownloaded() && NetworkUtilsAndReciever.isConnected(activity)) {
             if (isNewDownload(chapter.getId())) {
                 ChapterDownload dc = new ChapterDownload(chapter);
@@ -332,7 +335,6 @@ public class DownloadPoolService extends Service implements StateChangeListener 
     }
 
     private void initPool() {
-        mContext = getApplicationContext();
         Manga manga = null;
         ServerBase s = null;
         String path = "";

--- a/app/src/main/java/ar/rulosoft/mimanganu/services/DownloadPoolService.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/services/DownloadPoolService.java
@@ -156,20 +156,20 @@ public class DownloadPoolService extends Service implements StateChangeListener 
         attachListener(null, cid);
     }
 
-    public static String generateBasePath(ServerBase s, Manga m, Chapter c, Context context) {
+    public static String generateBasePath(ServerBase serverBase, Manga manga, Chapter chapter, Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String dir = prefs.getString("directorio",
                 Environment.getExternalStorageDirectory().getAbsolutePath());
-        return dir + "/MiMangaNu/" + cleanFileName(s.getServerName()) + "/" +
-                cleanFileName(m.getTitle()).trim() + "/" + cleanFileName(c.getTitle()).trim();
+        return dir + "/MiMangaNu/" + cleanFileName(serverBase.getServerName()) + "/" +
+                cleanFileName(manga.getTitle()).trim() + "/" + cleanFileName(chapter.getTitle()).trim();
     }
 
-    public static String generateBasePath(ServerBase s, Manga m, Context context) {
+    public static String generateBasePath(ServerBase serverBase, Manga manga, Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String dir = prefs.getString("directorio",
                 Environment.getExternalStorageDirectory().getAbsolutePath());
-        return dir + "/MiMangaNu/" + cleanFileName(s.getServerName()).trim() + "/" +
-                cleanFileName(m.getTitle()).trim();
+        return dir + "/MiMangaNu/" + cleanFileName(serverBase.getServerName()).trim() + "/" +
+                cleanFileName(manga.getTitle()).trim();
     }
 
     private static String cleanFileName(String badFileName) {
@@ -235,7 +235,6 @@ public class DownloadPoolService extends Service implements StateChangeListener 
     }
 
     public static void retryError(Context context , Chapter cid, ChapterDownload.OnErrorListener errorListener) {
-
             for (int i = 0; i < chapterDownloads.size(); i++) {
                 ChapterDownload cd = chapterDownloads.get(i);
                 if (cd.status == DownloadStatus.ERROR && cd.getChapter().getId() == cid.getId()) {

--- a/app/src/main/java/ar/rulosoft/mimanganu/services/SingleDownload.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/services/SingleDownload.java
@@ -58,7 +58,7 @@ public class SingleDownload implements Runnable {
                 Response response;
                 long contentLength;
                 try {
-                    OkHttpClient client = new Navegador(DownloadPoolService.mContext).getHttpClient();
+                    OkHttpClient client = new Navegador().getHttpClient();
                     if (reference)
                         client.networkInterceptors().add(new RefererInterceptor(cd.chapter.getPath()));
                     client.setConnectTimeout(3, TimeUnit.SECONDS);
@@ -80,7 +80,7 @@ public class SingleDownload implements Runnable {
                     input = response.body().byteStream();
                     output = new FileOutputStream(ot);
                 } catch (FileNotFoundException e) {
-                    Log.e("MIMANGA DOWNLOAD", "ERROR_WRITING_FILE");
+                    Log.e("SingleDownload", "ERROR_WRITING_FILE");
                     retry--;
                     if (retry > 0) {
                         changeStatus(Status.RETRY);
@@ -93,7 +93,7 @@ public class SingleDownload implements Runnable {
                         break;
                     }
                 } catch (IOException e) {
-                    Log.e("MIMANGA DOWNLOAD", "ERROR_OPENING_FILE");
+                    Log.e("SingleDownload", "ERROR_OPENING_FILE");
                     retry--;
                     if (retry > 0) {
                         changeStatus(Status.RETRY);
@@ -107,7 +107,8 @@ public class SingleDownload implements Runnable {
                     }
                 } catch (Exception e) {
                     retry = 0;
-                    Log.e("MIMANGA DOWNLOAD", "ERROR_CONNECTION " + e.getMessage());
+                    Log.e("SingleDownload", "ERROR_CONNECTION " + e.getMessage());
+                    e.printStackTrace();
                     changeStatus(Status.ERROR_CONNECTION);
                     break;
                 }
@@ -128,12 +129,12 @@ public class SingleDownload implements Runnable {
                     try {
                         Thread.sleep(3000);
                     } catch (InterruptedException e1) {}
-                    Log.e("MIMANGA DOWNLOAD", "ERROR_TIMEOUT");
+                    Log.e("SingleDownload", "ERROR_TIMEOUT");
                 } finally {
                     boolean flaggedOk = false;
                     if (status != Status.RETRY) {
                         if (contentLength > ot.length()) {
-                            Log.e("MIMANGA DOWNLOAD", "content length = " + contentLength + " size = " + o.length() + " on = " + o.getPath());
+                            Log.e("SingleDownload", "content length = " + contentLength + " size = " + o.length() + " on = " + o.getPath());
                             ot.delete();
                             retry--;
                             changeStatus(Status.RETRY);
@@ -154,7 +155,7 @@ public class SingleDownload implements Runnable {
                                 writeErrorImage(ot);
                                 ot.renameTo(o);
                             }
-                            //  Log.i("MIMANGA DOWNLOAD", "download ok =" + o.getPath());
+                            //  Log.i("SingleDownload", "download ok =" + o.getPath());
                             changeStatus(Status.DOWNLOAD_OK);
                         }
                     } catch (IOException e) {

--- a/app/src/main/java/ar/rulosoft/mimanganu/utils/NetworkUtilsAndReciever.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/utils/NetworkUtilsAndReciever.java
@@ -11,9 +11,11 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import ar.rulosoft.mimanganu.Exceptions.NoConnectionException;
 import ar.rulosoft.mimanganu.Exceptions.NoWifiException;
+import ar.rulosoft.mimanganu.MainActivity;
 import ar.rulosoft.mimanganu.services.AlarmReceiver;
 
 /*
@@ -23,6 +25,7 @@ import ar.rulosoft.mimanganu.services.AlarmReceiver;
 
 public class NetworkUtilsAndReciever extends BroadcastReceiver {
 
+    public enum ConnectionStatus {UNCHECKED, NO_INET_CONNECTED, NO_WIFI_CONNECTED, CONNECTED}
     public static ConnectionStatus connectionStatus = ConnectionStatus.UNCHECKED; //-1 not checked or changed, 0 no connection wifi, 1 no connection general, 2 connect
     public static boolean ONLY_WIFI;
 
@@ -124,20 +127,29 @@ public class NetworkUtilsAndReciever extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         connectionStatus = ConnectionStatus.UNCHECKED;
+
+        if (isWifiConnected(context) || isMobileConnected(context)) {
+            Log.d("NUAR", "onRec Connected");
+            MainActivity.isConnected = true;
+        } else {
+            Log.d("NUAR", "onRec Disconnected");
+            MainActivity.isConnected = false;
+        }
+
         try {
             if (isConnected(context)) {
                 SharedPreferences pm = PreferenceManager.getDefaultSharedPreferences(context);
-                long last_check = pm.getLong(AlarmReceiver.LAST_CHECK,0);
+                long last_check = pm.getLong(AlarmReceiver.LAST_CHECK, 0);
                 long current_time = System.currentTimeMillis();
                 long interval = pm.getLong("update_interval", 0);
-                if(interval > 0){
-                    if(interval < current_time - last_check){
+                if (interval > 0) {
+                    if (interval < current_time - last_check) {
                         new AlarmReceiver().onReceive(context, intent);
                     }
                 }
             }
-        } catch (Exception ignore) {}
+        } catch (Exception ignore) {
+        }
     }
 
-    public enum ConnectionStatus {UNCHECKED,NO_INET_CONNECTED,NO_WIFI_CONNECTED,CONNECTED}
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/utils/ThemeColors.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/utils/ThemeColors.java
@@ -1,6 +1,5 @@
 package ar.rulosoft.mimanganu.utils;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 
@@ -18,7 +17,7 @@ public class ThemeColors {
      * [3] pressed
      * [4] dark
      */
-    public static int[] getColors(SharedPreferences sp, Context context) {
+    public static int[] getColors(SharedPreferences sp) {
         int[] colors = new int[5];
         colors[0] = sp.getInt("primario", Color.parseColor("#2A52BE"));
         colors[1] = sp.getInt("secundario", Color.parseColor("#1E90FF"));

--- a/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
@@ -167,13 +167,14 @@ public class Util {
         notificationManager.notify(id, notification);
     }
 
-    public void changeSearchingForUpdatesNotification(int max, int progress, int id, String contentTitle, String contentText, boolean ongoing) {
+    public void changeSearchingForUpdatesNotification(Context context, int max, int progress, int id, String contentTitle, String contentText, boolean ongoing) {
         builder.setContentTitle(contentTitle);
         builder.setContentText(contentText);
         if (ongoing) {
             builder.setOngoing(true);
             if (progress == max) {
                 builder.setProgress(max, progress, true);
+                builder.setContentText(context.getResources().getString(R.string.finishing_update));
             } else {
                 builder.setProgress(max, progress, false);
             }

--- a/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
@@ -136,11 +136,11 @@ public class Util {
         });
     }
 
-    public void createSimpleNotification(Context context, boolean isPermanent, int id, Intent intent, String contentTitle, String contentText) {
+    public void createNotification(Context context, boolean isPermanent, int id, Intent intent, String contentTitle, String contentText) {
         Notification notification;
         PendingIntent pIntent = PendingIntent.getActivity(context, (int) System.currentTimeMillis(), intent, PendingIntent.FLAG_UPDATE_CURRENT);
         builder = new NotificationCompat.Builder(context);
-        builder.setOngoing(true).setContentTitle(contentTitle).setContentText(contentText).setSmallIcon(R.drawable.ic_launcher).setContentIntent(pIntent).setAutoCancel(true).build(); //setProgress(0, 0, isIndeterminate)
+        builder.setOngoing(true).setContentTitle(contentTitle).setContentText(contentText).setSmallIcon(R.drawable.ic_launcher).setContentIntent(pIntent).setAutoCancel(true).build();
         notificationManager = (NotificationManager) context.getSystemService(MainActivity.NOTIFICATION_SERVICE);
 
         notification = builder.build();
@@ -167,32 +167,23 @@ public class Util {
         notificationManager.notify(id, notification);
     }
 
-    public void changeNotification(int max, int progress, int id, String contentTitle, String contentText, boolean ongoing) {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            if (ongoing) {
-                if (progress == max)
-                    builder.setOngoing(true).setProgress(max, progress, true).setContentTitle(contentTitle).setContentText(contentText).setPriority(Notification.PRIORITY_HIGH);
-                else
-                    builder.setOngoing(true).setProgress(max, progress, false).setContentTitle(contentTitle).setContentText(contentText).setPriority(Notification.PRIORITY_HIGH);
+    public void changeSearchingForUpdatesNotification(int max, int progress, int id, String contentTitle, String contentText, boolean ongoing) {
+        builder.setContentTitle(contentTitle);
+        builder.setContentText(contentText);
+        if (ongoing) {
+            builder.setOngoing(true);
+            if (progress == max) {
+                builder.setProgress(max, progress, true);
+                builder.setContentText("Finishing Update ... (TODO)");
             } else {
-                if (progress == max)
-                    builder.setOngoing(false).setProgress(max, progress, true).setContentTitle(contentTitle).setContentText(contentText).setPriority(Notification.PRIORITY_HIGH);
-                else
-                    builder.setOngoing(false).setProgress(max, progress, false).setContentTitle(contentTitle).setContentText(contentText).setPriority(Notification.PRIORITY_HIGH);
+                builder.setProgress(max, progress, false);
             }
         } else {
-            if (ongoing) {
-                if (progress == max)
-                    builder.setOngoing(true).setProgress(max, progress, true).setContentTitle(contentTitle).setContentText(contentText);
-                else
-                    builder.setOngoing(true).setProgress(max, progress, false).setContentTitle(contentTitle).setContentText(contentText);
-            } else {
-                if (progress == max)
-                    builder.setOngoing(false).setProgress(max, progress, true).setContentTitle(contentTitle).setContentText(contentText);
-                else
-                    builder.setOngoing(false).setProgress(max, progress, false).setContentTitle(contentTitle).setContentText(contentText);
-            }
+            builder.setOngoing(false);
+            builder.setProgress(max, progress, false);
         }
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN)
+            builder.setPriority(Notification.PRIORITY_HIGH);
         notificationManager.notify(id, builder.build());
     }
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
@@ -174,7 +174,6 @@ public class Util {
             builder.setOngoing(true);
             if (progress == max) {
                 builder.setProgress(max, progress, true);
-                builder.setContentText("Finishing Update ... (TODO)");
             } else {
                 builder.setProgress(max, progress, false);
             }

--- a/app/src/main/java/ar/rulosoft/navegadores/Navegador.java
+++ b/app/src/main/java/ar/rulosoft/navegadores/Navegador.java
@@ -1,7 +1,5 @@
 package ar.rulosoft.navegadores;
 
-import android.content.Context;
-
 import com.squareup.okhttp.FormEncodingBuilder;
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
@@ -17,8 +15,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import ar.rulosoft.mimanganu.MainActivity;
-
 /**
  * @author Raul, nulldev, xtj-9182
  */
@@ -29,19 +25,7 @@ public class Navegador {
     private HashMap<String, String> parametros = new HashMap<>();
 
     public Navegador() throws Exception {
-        Context mContext;
-        if(MainActivity.mContext != null){
-            mContext = MainActivity.mContext;
-        }else{
-            throw new Exception("No context reached");
-        }
-        httpClient = new OkHttpClientConnectionChecker(mContext);
-        userAgentInterceptor = new UserAgentInterceptor("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:42.0) Gecko/20100101 Firefox/42.0");
-        httpClient.networkInterceptors().add(userAgentInterceptor);
-    }
-
-    public Navegador(Context mContext) throws Exception {
-        httpClient = new OkHttpClientConnectionChecker(mContext);
+        httpClient = new OkHttpClientConnectionChecker();
         userAgentInterceptor = new UserAgentInterceptor("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:42.0) Gecko/20100101 Firefox/42.0");
         httpClient.networkInterceptors().add(userAgentInterceptor);
     }

--- a/app/src/main/java/ar/rulosoft/navegadores/OkHttpClientConnectionChecker.java
+++ b/app/src/main/java/ar/rulosoft/navegadores/OkHttpClientConnectionChecker.java
@@ -1,24 +1,27 @@
 package ar.rulosoft.navegadores;
 
-import android.content.Context;
+import android.util.Log;
 
 import com.squareup.okhttp.OkHttpClient;
 
-import ar.rulosoft.mimanganu.Exceptions.NoConnectionException;
-import ar.rulosoft.mimanganu.Exceptions.NoWifiException;
+import ar.rulosoft.mimanganu.MainActivity;
 import ar.rulosoft.mimanganu.utils.NetworkUtilsAndReciever;
 
 /**
  * Created by Raul on 14/06/2016.
  */
 public class OkHttpClientConnectionChecker extends OkHttpClient {
-    public OkHttpClientConnectionChecker(Context context)throws Exception{
+    public OkHttpClientConnectionChecker() throws Exception {
         super();
-        if(!NetworkUtilsAndReciever.isConnected(context)){
-            if(NetworkUtilsAndReciever.ONLY_WIFI){
-                throw new NoWifiException(context);
-            }else{
-                throw new NoConnectionException(context);
+        if (!MainActivity.isConnected) {
+            if (NetworkUtilsAndReciever.ONLY_WIFI) {
+                Log.e("OkHttpClientConnectionC","no Wifi Exception");
+                throw new Exception();
+                //throw new NoWifiException(context);
+            } else {
+                Log.e("OkHttpClientConnectionC","no Connection Exception");
+                throw new Exception();
+                //throw new NoConnectionException(context);
             }
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -182,4 +182,5 @@
     <string name="misc_settings">Sonstige Einstellungen</string>
     <string name="edit_server_list">Serverliste bearbeiten</string>
     <string name="already_on_db">Manga bereits hinzugefügt</string>
+    <string name="downloading">Lade herunter: </string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -184,4 +184,5 @@
     <string name="reset_server_list_to_defaults_title">Resetear Lista de servidores</string>
     <string name="reset_server_list_to_defaults_subtitle">Mostrara todos los servidores escondidos.</string>
     <string name="misc_settings">Otras Configuraciones</string>
+    <string name="downloading">Descargando: </string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -182,4 +182,5 @@
     <string name="new_chapter">Nouveau chapitre de %s</string>
     <string name="misc_settings">Paramètres Divers</string>
     <string name="edit_server_list">Modifier la liste des serveurs</string>
+    <string name="downloading">Téléchargement: </string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -183,4 +183,5 @@
     <string name="new_chapter">Nuovo capitolo di %s</string>
     <string name="misc_settings">Impostazioni varie</string>
     <string name="edit_server_list">Modifica elenco dei server</string>
+    <string name="downloading">Scaricando: </string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -182,4 +182,5 @@
     <string name="new_chapter">Новая глава %s</string>
     <string name="misc_settings">Настройки Разное</string>
     <string name="edit_server_list">Редактирование списка серверов</string>
+    <string name="downloading">Скачивание: </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,7 +163,7 @@
     <string name="seamless_chapter_transitions_title">Seamless chapter transitions</string>
     <string name="seamless_chapter_transitions_paged_reader_subtitle">Press left or right on the first or last page of a chapter to load the previous or next chapter.</string>
     <string name="seamless_chapter_transitions_continuous_reader_subtitle">Swipe left or right (up or down for Vertical reading direction) on the first or last page of a chapter to load the previous or next chapter.</string>
-    <string name="show_notification_per_new_chapter_title">Show fine grained notifications</string>
+    <string name="show_notification_per_new_chapter_title">Show detailed notifications</string>
     <string name="show_notification_per_new_chapter_subtitle">Shows one notification per new chapter</string>
     <string name="download_next_chapter_automatically_title">Download next chapter</string>
     <string name="download_next_chapter_automatically_subtitle">While reading next chapter will be downloaded automatically</string>
@@ -182,6 +182,13 @@
     <string name="use_only_wifi_title">Use only WiFi</string>
     <string name="use_only_wifi_subtitle">To avoid data plan usage</string>
     <string name="reset_server_list_to_defaults_title">Reset server list to defaults</string>
-    <string name="reset_server_list_to_defaults_subtitle">This will unhide all servers</string>
+    <string name="reset_server_list_to_defaults_subtitle">This will un-hide all servers</string>
     <string name="search_result">Search result for \"%s\" on</string>
+    <string name="downloading">Downloading:</string>
+    <string name="update_search_cancelled">Update search cancelled</string>
+    <string name="finishing_update">Finishing Update &#8230;</string>
+    <string name="include_finished_manga_title">Include Finished Manga</string>
+    <string name="include_finished_manga_subtitle">This will include Manga that are marked as Finished. By default only Ongoing manga are included in the update search</string>
+    <string name="hide_sensitivity_scrollbar_title">Hide sensitivity scrollbar</string>
+    <string name="hide_sensitivity_scrollbar_subtitle">This will hide the sensitivity scrollbar when reading in non-Fullscreen mode</string>
 </resources>

--- a/app/src/main/res/xml/fragment_preferences.xml
+++ b/app/src/main/res/xml/fragment_preferences.xml
@@ -64,6 +64,11 @@
             android:key="show_notification_per_new_chapter"
             android:summary="@string/show_notification_per_new_chapter_subtitle"
             android:title="@string/show_notification_per_new_chapter_title" />
+        <android.support.v7.preference.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="include_finished_manga"
+            android:summary="@string/include_finished_manga_subtitle"
+            android:title="@string/include_finished_manga_title" />
     </android.support.v7.preference.PreferenceCategory>
 
     <android.support.v7.preference.PreferenceCategory android:title="@string/opciones_lec">
@@ -113,6 +118,11 @@
             android:key="seamless_chapter_transitions_delete_read"
             android:summary="@string/seamless_chapter_transitions_delete_read_subtitle"
             android:title="@string/seamless_chapter_transitions_delete_read_title" />
+        <android.support.v7.preference.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="hide_sensitivity_scrollbar"
+            android:summary="@string/hide_sensitivity_scrollbar_subtitle"
+            android:title="@string/hide_sensitivity_scrollbar_title" />
     </android.support.v7.preference.PreferenceCategory>
 
     <PreferenceCategory android:title="@string/opciones_descarga">


### PR DESCRIPTION
+ fix unnecessary PerformSearchTask call when going back to the SearchResultsFragment after performing a search
+ fix a notification bug + simplify notification code a bit
+ fix crash when going back from a Server before the AsyncTask would finish

Edit_27.06:
+ fix visual glitch when going to background and coming back while SwipeRefreshLayout is loading
+ Update search is now cancellable as long as no new chapters have been found yet just click on the notification for it to cancel (this only works as long as no new chapters have been found yet)
+ Attempt to fix NPE in DetailsFragment (around line ~100) reported by ACRA
+ resolve raulhaag#295
+ add setting to include Finished Manga in update search
(sometimes a finished manga gets a new chapter added. There is also the edge case that if a new chapter is added and the manga immediately changes to finished that users would previously not get these new chapters. Personal suggestions is to only activate this setting like once every few months)
+ add setting to hide sensitivity scrollbar when reading in non-Fullscreen mode
+ make some variables global to remove some getActivity calls, getActivity being null sometimes causes NPE crashes
+ switch loading of previous chapter to always use the saved pages
+ minor bug fixes