### PR TITLE
10 Updates/Changes/Bug Fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ android {
 }
 
 dependencies {
-    final ANDROID_SUPPORT = '24.2.0'
+    final ANDROID_SUPPORT = '24.2.1'
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile "com.android.support:support-v4:$ANDROID_SUPPORT"
     compile "com.android.support:design:$ANDROID_SUPPORT"

--- a/app/src/main/java/ar/rulosoft/mimanganu/ActivityReader.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ActivityReader.java
@@ -84,6 +84,7 @@ public class ActivityReader extends AppCompatActivity implements StateChangeList
     private boolean controlVisible = false;
     private MenuItem displayMenu;
     private AlertDialog mDialog = null;
+    private boolean redownloadingImage;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -440,7 +441,10 @@ public class ActivityReader extends AppCompatActivity implements StateChangeList
                 break;
             }
             case R.id.re_download_image:
-                reDownloadCurrentImage();
+                if(!redownloadingImage)
+                    reDownloadCurrentImage();
+                else
+                    Util.getInstance().toast(getApplicationContext(), getString(R.string.dont_spam_redownload_button));
                 break;
         }
         return super.onOptionsItemSelected(item);
@@ -593,6 +597,7 @@ public class ActivityReader extends AppCompatActivity implements StateChangeList
                             })
                             .show();
                 } catch (Exception e) {
+                    e.printStackTrace();
                     // lost references fixed con detachListener
                 }
             }
@@ -621,6 +626,7 @@ public class ActivityReader extends AppCompatActivity implements StateChangeList
                 mChapter.setPagesRead(1);
                 loadChapter(previousChapter, LoadMode.END);
                 //Util.getInstance().toast(getApplicationContext(), mChapter.getTitle(), 0);
+                Util.getInstance().showSlowSnackBar(mChapter.getTitle(), mControlsLayout, getApplicationContext());
             }
         }
     }
@@ -824,8 +830,7 @@ public class ActivityReader extends AppCompatActivity implements StateChangeList
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            if(!isDestroyed())
-                mActionBar.setVisibility(View.INVISIBLE);
+            redownloadingImage = true;
             idx = mReader.getCurrentPage();
             mReader.freePage(idx);
             path = mReader.getPath(idx);
@@ -857,8 +862,7 @@ public class ActivityReader extends AppCompatActivity implements StateChangeList
             if (error.length() > 3) {
                 Toast.makeText(ActivityReader.this, error, Toast.LENGTH_LONG).show();
             }
-            if(!isDestroyed())
-                mActionBar.setVisibility(View.VISIBLE);
+            redownloadingImage = false;
         }
     }
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/AutomaticUpdateTask.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/AutomaticUpdateTask.java
@@ -1,0 +1,162 @@
+package ar.rulosoft.mimanganu;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.AsyncTask;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+import java.util.ArrayList;
+
+import ar.rulosoft.mimanganu.componentes.Database;
+import ar.rulosoft.mimanganu.componentes.Manga;
+import ar.rulosoft.mimanganu.servers.ServerBase;
+import ar.rulosoft.mimanganu.utils.NetworkUtilsAndReciever;
+import ar.rulosoft.mimanganu.utils.Util;
+
+/**
+ * Created by jtx on 15.09.2016.
+ */
+public class AutomaticUpdateTask extends AsyncTask<Void, Integer, Integer> {
+    ArrayList<Manga> mangaList;
+    int threads = 2;
+    int ticket = threads;
+    int result = 0;
+    int numNow = 0;
+    String errorMsg = "";
+    Context context;
+    int mNotifyID = (int) System.currentTimeMillis();
+    SharedPreferences pm;
+
+    public AutomaticUpdateTask(Context context, SharedPreferences pm) {
+        this.context = context;
+        this.pm = pm;
+        if (pm.getBoolean("include_finished_manga", false))
+            mangaList = Database.getMangas(context, null, true);
+        else
+            mangaList = Database.getMangasForUpdates(context);
+        threads = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(context).getString("update_threads_manual", "2"));
+        ticket = threads;
+        mNotifyID = (int) System.currentTimeMillis();
+    }
+
+    @Override
+    protected void onPreExecute() {
+        super.onPreExecute();
+        if (context != null) {
+            try {
+                if (NetworkUtilsAndReciever.isConnected(context)) {
+                    Util.getInstance().createSearchingForUpdatesNotification(context, mNotifyID);
+                    Util.getInstance().showFastSnackBar(context.getResources().getString(R.string.searching_for_updates), context);
+                }
+            } catch (Exception e) {
+                if (e.getMessage() != null)
+                    errorMsg = e.getMessage();
+            }
+        }
+    }
+
+    @Override
+    protected void onProgressUpdate(Integer... values) {
+        if (context != null) {
+            Util.getInstance().changeSearchingForUpdatesNotification(context, mangaList.size(), ++numNow, mNotifyID, context.getResources().getString(R.string.searching_for_updates), numNow + "/" + mangaList.size() + " - " +
+                    mangaList.get(values[0]).getTitle(), true);
+        }
+        super.onProgressUpdate(values);
+    }
+
+    @Override
+    protected Integer doInBackground(Void... params) {
+        if (context != null && errorMsg.equals("")) {
+            final boolean fast = pm.getBoolean("fast_update", true);
+            ticket = threads;
+            for (int idx = 0; idx < mangaList.size(); idx++) {
+                if (Util.n > (48 - threads))
+                    cancel(true);
+                try {
+                    if (NetworkUtilsAndReciever.isConnected(context)) {
+                        final int idxNow = idx;
+                        // If there is no ticket, sleep for 1 second and ask again
+                        while (ticket < 1) {
+                            try {
+                                Thread.sleep(1000);
+                            } catch (InterruptedException e) {
+                                Log.e("ULT", "Update sleep failure", e);
+                            }
+                        }
+                        ticket--;
+
+                        // If tickets were passed, create new requests
+                        new Thread(new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    if (!isCancelled()) {
+                                        Manga manga = mangaList.get(idxNow);
+                                        ServerBase serverBase = ServerBase.getServer(manga.getServerId());
+                                        publishProgress(idxNow);
+                                        serverBase.loadChapters(manga, false);
+                                        result += serverBase.searchForNewChapters(manga.getId(), context, fast);
+                                    }
+                                } catch (Exception e) {
+                                    Log.e("ULT", "Update server failure", e);
+                                } finally {
+                                    ticket++;
+                                }
+                            }
+                        }).start();
+
+                    } else {
+                        Util.getInstance().cancelNotification(mNotifyID);
+                        break;
+                    }
+                } catch (Exception e) {
+                    if (e.getMessage() != null) {
+                        errorMsg = e.getMessage();
+                    }
+                }
+            }
+
+            // After finishing the loop, wait for all threads to finish their task before ending
+            while (ticket < threads) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Log.e("ULT", "After sleep failure", e);
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    protected void onPostExecute(Integer result) {
+        super.onPostExecute(result);
+        if (context != null) {
+            if (result > 0) {
+                Util.getInstance().cancelNotification(mNotifyID);
+                Util.getInstance().showFastSnackBar(context.getResources().getString(R.string.mgs_update_found, result), context);
+            } else {
+                Util.getInstance().cancelNotification(mNotifyID);
+                if (!errorMsg.equals("")) {
+                    Util.getInstance().showFastSnackBar(errorMsg, context);
+                } else {
+                    Util.getInstance().showFastSnackBar(context.getResources().getString(R.string.no_new_updates_found), context);
+                }
+            }
+        } else {
+            Util.getInstance().cancelNotification(mNotifyID);
+        }
+    }
+
+    @Override
+    protected void onCancelled() {
+        Util.getInstance().cancelNotification(mNotifyID);
+        if (context != null) {
+            Util.getInstance().toast(context, context.getString(R.string.update_search_cancelled));
+            if (Util.n > (48 - threads)) {
+                Util.getInstance().toast(context, context.getString(R.string.notification_tray_is_full));
+            }
+        }
+    }
+}

--- a/app/src/main/java/ar/rulosoft/mimanganu/MainActivity.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MainActivity.java
@@ -33,6 +33,7 @@ public class MainActivity extends AppCompatActivity {
     public static MainFragment.UpdateListTask updateListTask;
     public static boolean isConnected = true;
     public static CoordinatorLayout cLayout;
+    public static boolean coldStart;
     private final int WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST_CODE = 0;
     public ActionBar mActBar;
     OnBackListener backListener;
@@ -47,6 +48,7 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         if (isStoragePermissionGiven()) {
             if (savedInstanceState == null) {
+                coldStart = true;
                 MainFragment mainFragment = new MainFragment();
                 getSupportFragmentManager().beginTransaction().add(R.id.coordinator_layout, mainFragment).commit();
             }

--- a/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
@@ -102,6 +102,13 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
             }
         }
         pm = PreferenceManager.getDefaultSharedPreferences(getActivity());
+
+        long updaterInterval = Long.parseLong(pm.getString("update_interval", "0"));
+        if (MainActivity.coldStart && updaterInterval == -1) {
+            MainActivity.updateListTask = new UpdateListTask(getActivity());
+            MainActivity.updateListTask.execute();
+            MainActivity.coldStart = false;
+        }
     }
 
     @Override
@@ -600,7 +607,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
         int ticket = threads;
         int result = 0;
         int numNow = 0;
-        String errorMsg = "";
+        String error = "";
         Context context;
 
         public UpdateListTask(Context context) {
@@ -621,8 +628,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
                         Util.getInstance().showFastSnackBar(getResources().getString(R.string.searching_for_updates), getContext());
                     }
                 } catch (Exception e) {
-                    if (e.getMessage() != null)
-                        errorMsg = e.getMessage();
+                    error = Log.getStackTraceString(e);
                 }
             }
         }
@@ -638,7 +644,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
 
         @Override
         protected Integer doInBackground(Void... params) {
-            if (context != null && errorMsg.equals("")) {
+            if (context != null && error.equals("")) {
                 ticket = threads;
                 for (int idx = 0; idx < mangaList.size(); idx++) {
                     if (Util.n > (48 - threads))
@@ -690,9 +696,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
                             break;
                         }
                     } catch (Exception e) {
-                        if (e.getMessage() != null) {
-                            errorMsg = e.getMessage();
-                        }
+                        error = Log.getStackTraceString(e);
                     }
                 }
 
@@ -719,8 +723,8 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
                     Util.getInstance().showFastSnackBar(context.getResources().getString(R.string.mgs_update_found, result), context);
                 } else {
                     Util.getInstance().cancelNotification(mNotifyID);
-                    if (!errorMsg.equals("")) {
-                        Util.getInstance().showFastSnackBar(errorMsg, context);
+                    if (!error.equals("")) {
+                        Util.getInstance().showFastSnackBar(error, context);
                     } else {
                         Util.getInstance().showFastSnackBar(context.getResources().getString(R.string.no_new_updates_found), context);
                     }

--- a/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
@@ -105,8 +105,8 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
 
         long updaterInterval = Long.parseLong(pm.getString("update_interval", "0"));
         if (MainActivity.coldStart && updaterInterval == -1) {
-            MainActivity.updateListTask = new UpdateListTask(getActivity());
-            MainActivity.updateListTask.execute();
+            AutomaticUpdateTask automaticUpdateTask = new AutomaticUpdateTask(getContext(), pm);
+            automaticUpdateTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
             MainActivity.coldStart = false;
         }
     }

--- a/app/src/main/java/ar/rulosoft/mimanganu/MangaFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MangaFragment.java
@@ -773,7 +773,6 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         private Chapter chapter;
         int threads = Runtime.getRuntime().availableProcessors();
         int ticket = threads;
-        int count = 0;
 
         public MarkSelectedAsRead(int selectionSize) {
             super();
@@ -796,7 +795,6 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
                 final int idxNow = i;
                 while (ticket < 1) {
                     if (System.currentTimeMillis() - initTime > 250) {
-                        count++;
                         publishProgress(i);
                         initTime = System.currentTimeMillis();
                     }
@@ -863,7 +861,6 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         private Chapter chapter;
         int threads = Runtime.getRuntime().availableProcessors();
         int ticket = threads;
-        int count = 0;
 
         public MarkSelectedAsUnread(int selectionSize) {
             super();
@@ -886,7 +883,6 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
                 final int idxNow = i;
                 while (ticket < 1) {
                     if (System.currentTimeMillis() - initTime > 250) {
-                        count++;
                         publishProgress(i);
                         initTime = System.currentTimeMillis();
                     }
@@ -955,7 +951,6 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         private Chapter chapter;
         int threads = Runtime.getRuntime().availableProcessors();
         int ticket = threads;
-        int count = 0;
 
         public DeleteImages(ServerBase serverBase, int selectionSize) {
             this.serverBase = serverBase;
@@ -978,7 +973,6 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
                 final int idxNow = i;
                 while (ticket < 1) {
                     if (System.currentTimeMillis() - initTime > 250) {
-                        count++;
                         publishProgress(i);
                         initTime = System.currentTimeMillis();
                     }
@@ -1112,7 +1106,6 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         private Chapter chapter;
         int threads = Runtime.getRuntime().availableProcessors();
         int ticket = threads;
-        int count = 0;
 
         public ResetChapters(ServerBase serverBase, int selectionSize) {
             this.serverBase = serverBase;
@@ -1135,7 +1128,6 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
                 final int idxNow = i;
                 while (ticket < 1) {
                     if (System.currentTimeMillis() - initTime > 250) {
-                        count++;
                         publishProgress(i);
                         initTime = System.currentTimeMillis();
                     }

--- a/app/src/main/java/ar/rulosoft/mimanganu/MangaFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MangaFragment.java
@@ -205,12 +205,12 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
                                 .setAction(android.R.string.yes, new View.OnClickListener() {
                                     @Override
                                     public void onClick(View view) {
-                                        SparseBooleanArray selection = mChapterAdapter.getSelection();
+                                        /*SparseBooleanArray selection = mChapterAdapter.getSelection();
                                         int[] selected = new int[selection.size()];
                                         for (int j = 0; j < selection.size(); j++) {
                                             selected[j] = selection.keyAt(j);
                                         }
-                                        Arrays.sort(selected);
+                                        Arrays.sort(selected);*/
 
                                         if(selection.size() < 8) {
                                             // Remove chapters on UI Thread
@@ -771,6 +771,9 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
     private class MarkSelectedAsRead extends AsyncTask<Void, Integer, Void> {
         private int selectionSize = 0;
         private Chapter chapter;
+        int threads = Runtime.getRuntime().availableProcessors();
+        int ticket = threads;
+        int count = 0;
 
         public MarkSelectedAsRead(int selectionSize) {
             super();
@@ -781,22 +784,53 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            Util.getInstance().createNotificationWithProgressbar(getContext(), mNotifyID_MarkSelectedAsRead, getString(R.string.marking_as_read), "");
+            if(selectionSize > 7)
+                Util.getInstance().createNotificationWithProgressbar(getContext(), mNotifyID_MarkSelectedAsRead, getString(R.string.marking_as_read), "");
         }
 
         @Override
         protected Void doInBackground(Void... params) {
+            ticket = threads;
             long initTime = System.currentTimeMillis();
             for (int i = 0; i < selectionSize; i++) {
-                if(isAdded() && !isCancelled()) {
-                    if (mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(i)).getReadStatus() != 1) {
-                        chapter = mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(i));
-                        chapter.markRead(getActivity(), true);
-                        if (System.currentTimeMillis() - initTime > 250) {
-                            publishProgress(i);
-                            initTime = System.currentTimeMillis();
-                        }
+                final int idxNow = i;
+                while (ticket < 1) {
+                    if (System.currentTimeMillis() - initTime > 250) {
+                        count++;
+                        publishProgress(i);
+                        initTime = System.currentTimeMillis();
                     }
+                }
+                ticket--;
+
+                if (mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(i)).getReadStatus() != 1) {
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                if (isAdded() && !isCancelled()) {
+                                    chapter = mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(idxNow));
+                                    chapter.markRead(getActivity(), true);
+                                }
+                            } catch (Exception e) {
+                                Log.e(TAG, Log.getStackTraceString(e));
+                            } finally {
+                                ticket++;
+                            }
+
+                        }
+                    }).start();
+                } else {
+                    ticket++;
+                }
+            } //for loop
+
+            publishProgress(selectionSize);
+            while (ticket < threads) {
+                try {
+                    Thread.sleep(250);
+                } catch (InterruptedException e) {
+                    Log.e(TAG, "After sleep failure", e);
                 }
             }
             return null;
@@ -806,24 +840,30 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         protected void onProgressUpdate(final Integer... values) {
             super.onProgressUpdate(values);
             mChapterAdapter.notifyDataSetChanged();
-            Util.getInstance().changeNotificationWithProgressbar(selectionSize, values[0], mNotifyID_MarkSelectedAsRead, getString(R.string.marking_as_read), chapter.getTitle(), true);
+            if(selectionSize > 7)
+                Util.getInstance().changeNotificationWithProgressbar(selectionSize, values[0], mNotifyID_MarkSelectedAsRead, getString(R.string.marking_as_read), chapter.getTitle(), true);
         }
 
         @Override
         protected void onPostExecute(Void aVoid) {
             mChapterAdapter.notifyDataSetChanged();
-            Util.getInstance().cancelNotification(mNotifyID_MarkSelectedAsRead);
+            if(selectionSize > 7)
+                Util.getInstance().cancelNotification(mNotifyID_MarkSelectedAsRead);
         }
 
         @Override
         protected void onCancelled() {
-            Util.getInstance().cancelNotification(mNotifyID_MarkSelectedAsRead);
+            if(selectionSize > 7)
+                Util.getInstance().cancelNotification(mNotifyID_MarkSelectedAsRead);
         }
     }
 
     private class MarkSelectedAsUnread extends AsyncTask<Void, Integer, Void> {
         private int selectionSize = 0;
         private Chapter chapter;
+        int threads = Runtime.getRuntime().availableProcessors();
+        int ticket = threads;
+        int count = 0;
 
         public MarkSelectedAsUnread(int selectionSize) {
             super();
@@ -834,24 +874,56 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            Util.getInstance().createNotificationWithProgressbar(getContext(), mNotifyID_MarkSelectedAsUnread, getString(R.string.marking_as_unread), "");
+            if(selectionSize > 7)
+                Util.getInstance().createNotificationWithProgressbar(getContext(), mNotifyID_MarkSelectedAsUnread, getString(R.string.marking_as_unread), "");
         }
 
         @Override
         protected Void doInBackground(Void... params) {
+            ticket = threads;
             long initTime = System.currentTimeMillis();
             for (int i = 0; i < selectionSize; i++) {
-                if(isAdded() && !isCancelled()) {
-                    if (mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(i)).getReadStatus() != 0) {
-                        chapter = mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(i));
-                        chapter.markRead(getActivity(), false);
-                        if (System.currentTimeMillis() - initTime > 250) {
-                            publishProgress(i);
-                            initTime = System.currentTimeMillis();
-                        }
+                final int idxNow = i;
+                while (ticket < 1) {
+                    if (System.currentTimeMillis() - initTime > 250) {
+                        count++;
+                        publishProgress(i);
+                        initTime = System.currentTimeMillis();
                     }
                 }
+                ticket--;
+
+                if (mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(i)).getReadStatus() != 0) {
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                if (isAdded() && !isCancelled()) {
+                                    chapter = mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(idxNow));
+                                    chapter.markRead(getActivity(), false);
+                                }
+                            } catch (Exception e) {
+                                Log.e(TAG, Log.getStackTraceString(e));
+                            } finally {
+                                ticket++;
+                            }
+
+                        }
+                    }).start();
+                } else {
+                    ticket++;
+                }
+            } //for loop
+
+            publishProgress(selectionSize);
+            while (ticket < threads) {
+                try {
+                    Thread.sleep(250);
+                } catch (InterruptedException e) {
+                    Log.e(TAG, "After sleep failure", e);
+                }
             }
+
             return null;
         }
 
@@ -859,18 +931,21 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         protected void onProgressUpdate(final Integer... values) {
             super.onProgressUpdate(values);
             mChapterAdapter.notifyDataSetChanged();
-            Util.getInstance().changeNotificationWithProgressbar(selectionSize, values[0], mNotifyID_MarkSelectedAsUnread, getString(R.string.marking_as_unread), chapter.getTitle(), true);
+            if(selectionSize > 7)
+                Util.getInstance().changeNotificationWithProgressbar(selectionSize, values[0], mNotifyID_MarkSelectedAsUnread, getString(R.string.marking_as_unread), chapter.getTitle(), true);
         }
 
         @Override
         protected void onPostExecute(Void aVoid) {
             mChapterAdapter.notifyDataSetChanged();
-            Util.getInstance().cancelNotification(mNotifyID_MarkSelectedAsUnread);
+            if(selectionSize > 7)
+                Util.getInstance().cancelNotification(mNotifyID_MarkSelectedAsUnread);
         }
 
         @Override
         protected void onCancelled() {
-            Util.getInstance().cancelNotification(mNotifyID_MarkSelectedAsUnread);
+            if(selectionSize > 7)
+                Util.getInstance().cancelNotification(mNotifyID_MarkSelectedAsUnread);
         }
     }
 
@@ -878,6 +953,9 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         private ServerBase serverBase;
         private int selectionSize = 0;
         private Chapter chapter;
+        int threads = Runtime.getRuntime().availableProcessors();
+        int ticket = threads;
+        int count = 0;
 
         public DeleteImages(ServerBase serverBase, int selectionSize) {
             this.serverBase = serverBase;
@@ -888,20 +966,49 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            Util.getInstance().createNotificationWithProgressbar(getContext(), mNotifyID_DeleteImages, getString(R.string.deleting), "");
+            if(selectionSize > 7)
+                Util.getInstance().createNotificationWithProgressbar(getContext(), mNotifyID_DeleteImages, getString(R.string.deleting), "");
         }
 
         @Override
         protected Integer doInBackground(Void... params) {
+            ticket = threads;
             long initTime = System.currentTimeMillis();
             for (int i = 0; i < selectionSize; i++) {
-                if(isAdded() && !isCancelled()) {
-                    chapter = mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(i));
-                    chapter.freeSpace(getActivity(), mManga, serverBase);
+                final int idxNow = i;
+                while (ticket < 1) {
                     if (System.currentTimeMillis() - initTime > 250) {
+                        count++;
                         publishProgress(i);
                         initTime = System.currentTimeMillis();
                     }
+                }
+                ticket--;
+
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            if (isAdded() && !isCancelled()) {
+                                chapter = mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(idxNow));
+                                chapter.freeSpace(getActivity(), mManga, serverBase);
+                            }
+                        } catch (Exception e) {
+                            Log.e(TAG, Log.getStackTraceString(e));
+                        } finally {
+                            ticket++;
+                        }
+
+                    }
+                }).start();
+            } //for loop
+
+            publishProgress(selectionSize);
+            while (ticket < threads) {
+                try {
+                    Thread.sleep(250);
+                } catch (InterruptedException e) {
+                    Log.e(TAG, "After sleep failure", e);
                 }
             }
 
@@ -912,19 +1019,22 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         protected void onProgressUpdate(final Integer... values) {
             super.onProgressUpdate(values);
             mChapterAdapter.notifyDataSetChanged();
-            Util.getInstance().changeNotificationWithProgressbar(selectionSize, values[0], mNotifyID_DeleteImages, getString(R.string.deleting), chapter.getTitle(), true);
+            if(selectionSize > 7)
+                Util.getInstance().changeNotificationWithProgressbar(selectionSize, values[0], mNotifyID_DeleteImages, getString(R.string.deleting), chapter.getTitle(), true);
         }
 
         @Override
         protected void onPostExecute(Integer result) {
             super.onPostExecute(result);
             mChapterAdapter.notifyDataSetChanged();
-            Util.getInstance().cancelNotification(mNotifyID_DeleteImages);
+            if(selectionSize > 7)
+                Util.getInstance().cancelNotification(mNotifyID_DeleteImages);
         }
 
         @Override
         protected void onCancelled() {
-            Util.getInstance().cancelNotification(mNotifyID_DeleteImages);
+            if(selectionSize > 7)
+                Util.getInstance().cancelNotification(mNotifyID_DeleteImages);
         }
     }
 
@@ -970,6 +1080,7 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
                     }
                 }
             }
+            publishProgress(selectionSize - 1);
 
             return null;
         }
@@ -977,7 +1088,7 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         @Override
         protected void onProgressUpdate(final Integer... values) {
             super.onProgressUpdate(values);
-            Util.getInstance().changeNotificationWithProgressbar(selectionSize, values[0], mNotifyID_RemoveChapters, getString(R.string.removing_chapters), chapter.getTitle(), true);
+            Util.getInstance().changeNotificationWithProgressbar(selectionSize - 1, values[0], mNotifyID_RemoveChapters, getString(R.string.removing_chapters), chapter.getTitle(), true);
         }
 
         @Override
@@ -999,6 +1110,9 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         private ServerBase serverBase;
         private int selectionSize = 0;
         private Chapter chapter;
+        int threads = Runtime.getRuntime().availableProcessors();
+        int ticket = threads;
+        int count = 0;
 
         public ResetChapters(ServerBase serverBase, int selectionSize) {
             this.serverBase = serverBase;
@@ -1009,20 +1123,49 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            Util.getInstance().createNotificationWithProgressbar(getContext(), mNotifyID_ResetChapters, getString(R.string.resetting_chapters), "");
+            if(selectionSize > 7)
+                Util.getInstance().createNotificationWithProgressbar(getContext(), mNotifyID_ResetChapters, getString(R.string.resetting_chapters), "");
         }
 
         @Override
         protected Integer doInBackground(Void... params) {
+            ticket = threads;
             long initTime = System.currentTimeMillis();
             for (int i = 0; i < selectionSize; i++) {
-                if(isAdded() && !isCancelled()) {
-                    chapter = mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(i));
-                    chapter.reset(getActivity(), mManga, serverBase);
+                final int idxNow = i;
+                while (ticket < 1) {
                     if (System.currentTimeMillis() - initTime > 250) {
+                        count++;
                         publishProgress(i);
                         initTime = System.currentTimeMillis();
                     }
+                }
+                ticket--;
+
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            if (isAdded() && !isCancelled()) {
+                                chapter = mChapterAdapter.getItem(mChapterAdapter.getSelection().keyAt(idxNow));
+                                chapter.reset(getActivity(), mManga, serverBase);
+                            }
+                        } catch (Exception e) {
+                            Log.e(TAG, Log.getStackTraceString(e));
+                        } finally {
+                            ticket++;
+                        }
+
+                    }
+                }).start();
+            } //for loop
+
+            publishProgress(selectionSize);
+            while (ticket < threads) {
+                try {
+                    Thread.sleep(250);
+                } catch (InterruptedException e) {
+                    Log.e(TAG, "After sleep failure", e);
                 }
             }
 
@@ -1032,7 +1175,8 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
         @Override
         protected void onProgressUpdate(final Integer... values) {
             super.onProgressUpdate(values);
-            Util.getInstance().changeNotificationWithProgressbar(selectionSize, values[0], mNotifyID_ResetChapters, getString(R.string.resetting_chapters), chapter.getTitle(), true);
+            if(selectionSize > 7)
+                Util.getInstance().changeNotificationWithProgressbar(selectionSize, values[0], mNotifyID_ResetChapters, getString(R.string.resetting_chapters), chapter.getTitle(), true);
         }
 
         @Override
@@ -1040,12 +1184,14 @@ public class MangaFragment extends Fragment implements MainActivity.OnKeyUpListe
             super.onPostExecute(result);
             if(isAdded())
                 new SortAndLoadChapters().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-            Util.getInstance().cancelNotification(mNotifyID_ResetChapters);
+            if(selectionSize > 7)
+                Util.getInstance().cancelNotification(mNotifyID_ResetChapters);
         }
 
         @Override
         protected void onCancelled() {
-            Util.getInstance().cancelNotification(mNotifyID_ResetChapters);
+            if(selectionSize > 7)
+                Util.getInstance().cancelNotification(mNotifyID_ResetChapters);
         }
     }
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
@@ -202,11 +202,15 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
                 } else {
                     AlarmReceiver.stopAlarms(getActivity().getApplicationContext());
                 }
+
+                if(time == -1)
+                    MainActivity.coldStart = false;
+
                 return true;
             }
         });
 
-        /** This.. sets the Version Number, that's all */
+        /** This sets the Version Number, that's all */
         final Preference prefAbout = getPreferenceManager().findPreference("about_text");
         prefAbout.setSummary("v" + BuildConfig.VERSION_NAME);
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/Database.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/Database.java
@@ -149,7 +149,13 @@ public class Database extends SQLiteOpenHelper {
     public static int addManga(Context context, Manga manga) {
         int tmp = -1;
         try {
-            tmp = (int) getDatabase(context).insertOrThrow(TABLE_MANGA, null, setMangaCV(manga, true));
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly())
+                tmp = (int) database.insertOrThrow(TABLE_MANGA, null, setMangaCV(manga, true));
+            else {
+                Log.e("Database", "(addManga) " + context.getResources().getString(R.string.error_database_is_read_only));
+                Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+            }
         } catch (Exception e){
             Log.e("Database", Log.getStackTraceString(e));
             Util.getInstance().toast(context, context.getResources().getString(R.string.error_while_adding_chapter_or_manga_to_db, manga.getTitle()));
@@ -166,8 +172,9 @@ public class Database extends SQLiteOpenHelper {
      */
     public static void updateManga(Context context, Manga manga, boolean setTime) {
         try {
-            if (!getDatabase(context).isReadOnly())
-                getDatabase(context).update(TABLE_MANGA, setMangaCV(manga, setTime), COL_ID + "=" + manga.getId(), null);
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly())
+                database.update(TABLE_MANGA, setMangaCV(manga, setTime), COL_ID + "=" + manga.getId(), null);
             else {
                 Log.e("Database", "(updateManga) " + context.getResources().getString(R.string.error_database_is_read_only));
                 Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
@@ -192,8 +199,9 @@ public class Database extends SQLiteOpenHelper {
         cv.put(COL_LAST_READ, System.currentTimeMillis());
         cv.put(COL_NEW, 0);
         try {
-            if (!getDatabase(c).isReadOnly())
-                getDatabase(c).update(TABLE_MANGA, cv, COL_ID + "=" + mid, null);
+            SQLiteDatabase database = getDatabase(c);
+            if (!database.isReadOnly())
+                database.update(TABLE_MANGA, cv, COL_ID + "=" + mid, null);
             else {
                 Log.e("Database", "(updateMangaRead) " + c.getResources().getString(R.string.error_database_is_read_only));
                 Util.getInstance().toast(c, c.getResources().getString(R.string.error_database_is_read_only));
@@ -214,8 +222,9 @@ public class Database extends SQLiteOpenHelper {
         ContentValues cv = new ContentValues();
         cv.put(COL_SEARCH, buscar ? 1 : 0);
         try {
-            if (!getDatabase(c).isReadOnly())
-                getDatabase(c).update(TABLE_MANGA, cv, COL_ID + "=" + mangaid, null);
+            SQLiteDatabase database = getDatabase(c);
+            if (!database.isReadOnly())
+                database.update(TABLE_MANGA, cv, COL_ID + "=" + mangaid, null);
             else {
                 Log.e("Database", "(setUpgradable) " + c.getResources().getString(R.string.error_database_is_read_only));
                 Util.getInstance().toast(c, c.getResources().getString(R.string.error_database_is_read_only));
@@ -236,8 +245,9 @@ public class Database extends SQLiteOpenHelper {
         ContentValues cv = new ContentValues();
         cv.put(COL_LAST_INDEX, idx);
         try {
-            if (!getDatabase(c).isReadOnly())
-                getDatabase(c).update(TABLE_MANGA, cv, COL_ID + "=" + mid, null);
+            SQLiteDatabase database = getDatabase(c);
+            if (!database.isReadOnly())
+                database.update(TABLE_MANGA, cv, COL_ID + "=" + mid, null);
             else {
                 Log.e("Database", "(updateMangaLastIndex) " + c.getResources().getString(R.string.error_database_is_read_only));
                 Util.getInstance().toast(c, c.getResources().getString(R.string.error_database_is_read_only));
@@ -258,8 +268,9 @@ public class Database extends SQLiteOpenHelper {
         ContentValues cv = new ContentValues();
         cv.put(COL_SCROLL_SENSITIVE, nScroll);
         try {
-            if (!getDatabase(c).isReadOnly())
-                getDatabase(c).update(TABLE_MANGA, cv, COL_ID + "=" + mid, null);
+            SQLiteDatabase database = getDatabase(c);
+            if (!database.isReadOnly())
+                database.update(TABLE_MANGA, cv, COL_ID + "=" + mid, null);
             else {
                 Log.e("Database", "(updateMangaScrollSensitive) " + c.getResources().getString(R.string.error_database_is_read_only));
                 Util.getInstance().toast(c, c.getResources().getString(R.string.error_database_is_read_only));
@@ -306,7 +317,13 @@ public class Database extends SQLiteOpenHelper {
         contentValues.put(COL_CAP_DOWNLOADED, chapter.isDownloaded());
         contentValues.put(COL_CAP_EXTRA, chapter.getExtra());
         try {
-            getDatabase(context).insertOrThrow(TABLE_CHAPTERS, null, contentValues);
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly())
+                database.insertOrThrow(TABLE_CHAPTERS, null, contentValues);
+            else {
+                Log.e("Database", "(addChapter) " + context.getResources().getString(R.string.error_database_is_read_only));
+                Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+            }
         } catch (SQLiteConstraintException sqlce) {
             // remove orphaned chapters and try again
             try {
@@ -333,7 +350,13 @@ public class Database extends SQLiteOpenHelper {
         cv.put(COL_CAP_PAG_READ, chapter.getPagesRead());
         cv.put(COL_CAP_EXTRA,chapter.getExtra());
         try {
-            getDatabase(context).update(TABLE_CHAPTERS, cv, COL_CAP_ID + " = " + chapter.getId(), null);
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly())
+                database.update(TABLE_CHAPTERS, cv, COL_CAP_ID + " = " + chapter.getId(), null);
+            else {
+                Log.e("Database", "(updateChapter) " + context.getResources().getString(R.string.error_database_is_read_only));
+                Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+            }
         } catch (SQLiteFullException sqlfe) {
             Log.e("Database", "" + Log.getStackTraceString(sqlfe));
             outputChapterDebugInformation(chapter);
@@ -364,7 +387,7 @@ public class Database extends SQLiteOpenHelper {
         Log.i("Database", "Pages Read: " + chapter.getPagesRead());
         Log.i("Database", "Read Status: " + chapter.getReadStatus());
         Log.i("Database", "isDownloaded: " + chapter.isDownloaded());
-        Log.i("Database", "Extra: " + chapter.getExtra());
+        //Log.i("Database", "Extra: " + chapter.getExtra());
     }
 
     private static void outputChapterDebugInformation(Chapter chapter) {
@@ -374,7 +397,7 @@ public class Database extends SQLiteOpenHelper {
         Log.i("Database", "Pages Read: " + chapter.getPagesRead());
         Log.i("Database", "Read Status: " + chapter.getReadStatus());
         Log.i("Database", "isDownloaded: " + chapter.isDownloaded());
-        Log.i("Database", "Extra: " + chapter.getExtra());
+        //Log.i("Database", "Extra: " + chapter.getExtra());
     }
 
     public static ArrayList<Manga> getMangasForUpdates(Context context) {
@@ -538,7 +561,13 @@ public class Database extends SQLiteOpenHelper {
         ContentValues cv = new ContentValues();
         cv.put(COL_CAP_DOWNLOADED, state);
         try {
-            getDatabase(context).update(TABLE_CHAPTERS, cv, COL_CAP_ID + "=" + Integer.toString(cid), null);
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly())
+                database.update(TABLE_CHAPTERS, cv, COL_CAP_ID + "=" + Integer.toString(cid), null);
+            else {
+                Log.e("Database", "(updateChapterDownloaded) " + context.getResources().getString(R.string.error_database_is_read_only));
+                Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+            }
         } catch (SQLiteFullException sqlfe) {
             Log.e("Database", Log.getStackTraceString(sqlfe));
             Util.getInstance().toast(context, context.getResources().getString(R.string.error_sqlite_full_exception));
@@ -560,7 +589,13 @@ public class Database extends SQLiteOpenHelper {
         cv.put(COL_CAP_PAG_READ, cap.getPagesRead());
         cv.put(COL_CAP_DOWNLOADED, cap.isDownloaded() ? 1 : 0);
         try {
-            getDatabase(context).update(TABLE_CHAPTERS, cv, COL_CAP_ID + " = " + cap.getId(), null);
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly())
+                database.update(TABLE_CHAPTERS, cv, COL_CAP_ID + " = " + cap.getId(), null);
+            else {
+                Log.e("Database", "(updateChapterPlusDownload) " + context.getResources().getString(R.string.error_database_is_read_only));
+                Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+            }
         } catch (SQLiteFullException sqlfe) {
             Log.e("Database", Log.getStackTraceString(sqlfe));
             Util.getInstance().toast(context, context.getResources().getString(R.string.error_sqlite_full_exception));
@@ -577,7 +612,13 @@ public class Database extends SQLiteOpenHelper {
         ContentValues cv = new ContentValues();
         cv.put(COL_CAP_PAG_READ, pages);
         try {
-            getDatabase(context).update(TABLE_CHAPTERS, cv, COL_CAP_ID + "=" + Integer.toString(cid), null);
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly())
+                database.update(TABLE_CHAPTERS, cv, COL_CAP_ID + "=" + Integer.toString(cid), null);
+            else {
+                Log.e("Database", "(updateChapterPage) " + context.getResources().getString(R.string.error_database_is_read_only));
+                Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+            }
         } catch (SQLiteFullException sqlfe) {
             Log.e("Database", Log.getStackTraceString(sqlfe));
             Util.getInstance().toast(context, context.getResources().getString(R.string.error_sqlite_full_exception));
@@ -591,12 +632,24 @@ public class Database extends SQLiteOpenHelper {
     }
 
     public static void deleteManga(Context c, int mid) {
-        getDatabase(c).delete(TABLE_MANGA, COL_ID + " = " + mid, null);
-        getDatabase(c).delete(TABLE_CHAPTERS, COL_CAP_ID_MANGA + "=" + mid, null);
+        SQLiteDatabase database = getDatabase(c);
+        if (!database.isReadOnly()) {
+            database.delete(TABLE_MANGA, COL_ID + " = " + mid, null);
+            database.delete(TABLE_CHAPTERS, COL_CAP_ID_MANGA + "=" + mid, null);
+        } else {
+            Log.e("Database", "(deleteManga) " + c.getResources().getString(R.string.error_database_is_read_only));
+            Util.getInstance().toast(c, c.getResources().getString(R.string.error_database_is_read_only));
+        }
     }
 
     public static void deleteChapter(Context context, Chapter chapter) {
-        getDatabase(context).delete(TABLE_CHAPTERS, COL_CAP_ID + "=" + chapter.getId(), null);
+        SQLiteDatabase database = getDatabase(context);
+        if (!database.isReadOnly()) {
+            database.delete(TABLE_CHAPTERS, COL_CAP_ID + "=" + chapter.getId(), null);
+        } else {
+            Log.e("Database", "(deleteChapter) " + context.getResources().getString(R.string.error_database_is_read_only));
+            Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+        }
     }
 
     public static Manga getManga(Context context, int mangaID) {
@@ -644,7 +697,13 @@ public class Database extends SQLiteOpenHelper {
         ContentValues cv = new ContentValues();
         cv.put(COL_CAP_STATE, read ? Chapter.READ : Chapter.UNREAD);
         try {
-            getDatabase(context).update(TABLE_CHAPTERS, cv, COL_CAP_ID + " = " + capId, null);
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly()) {
+                database.update(TABLE_CHAPTERS, cv, COL_CAP_ID + " = " + capId, null);
+            } else {
+                Log.e("Database", "(markChapter) " + context.getResources().getString(R.string.error_database_is_read_only));
+                Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+            }
         } catch (SQLiteFullException sqlfe) {
             Log.e("Database", Log.getStackTraceString(sqlfe));
             Util.getInstance().toast(context, context.getResources().getString(R.string.error_sqlite_full_exception));
@@ -661,7 +720,13 @@ public class Database extends SQLiteOpenHelper {
         ContentValues cv = new ContentValues();
         cv.put(COL_CAP_STATE, read ? Chapter.READ : Chapter.UNREAD);
         try {
-            getDatabase(context).update(TABLE_CHAPTERS, cv, COL_CAP_ID_MANGA + " = " + mangaId, null);
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly()) {
+                database.update(TABLE_CHAPTERS, cv, COL_CAP_ID_MANGA + " = " + mangaId, null);
+            } else {
+                Log.e("Database", "(markAllChapters) " + context.getResources().getString(R.string.error_database_is_read_only));
+                Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+            }
         } catch (SQLiteFullException sqlfe) {
             Log.e("Database", Log.getStackTraceString(sqlfe));
             Util.getInstance().toast(context, context.getResources().getString(R.string.error_sqlite_full_exception));
@@ -682,7 +747,13 @@ public class Database extends SQLiteOpenHelper {
         ContentValues cv = new ContentValues();
         cv.put(COL_READ_ORDER, ordinal);
         try {
-            getDatabase(context).update(TABLE_MANGA, cv, COL_ID + "=" + mid, null);
+            SQLiteDatabase database = getDatabase(context);
+            if (!database.isReadOnly()) {
+                database.update(TABLE_MANGA, cv, COL_ID + "=" + mid, null);
+            } else {
+                Log.e("Database", "(updateReadOrder) " + context.getResources().getString(R.string.error_database_is_read_only));
+                Util.getInstance().toast(context, context.getResources().getString(R.string.error_database_is_read_only));
+            }
         } catch (SQLiteFullException sqlfe) {
             Log.e("Database", Log.getStackTraceString(sqlfe));
             Util.getInstance().toast(context, context.getResources().getString(R.string.error_sqlite_full_exception));

--- a/app/src/main/java/ar/rulosoft/mimanganu/utils/NetworkUtilsAndReciever.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/utils/NetworkUtilsAndReciever.java
@@ -152,14 +152,15 @@ public class NetworkUtilsAndReciever extends BroadcastReceiver {
                 SharedPreferences pm = PreferenceManager.getDefaultSharedPreferences(context);
                 long last_check = pm.getLong(AlarmReceiver.LAST_CHECK, 0);
                 long current_time = System.currentTimeMillis();
-                long interval = pm.getLong("update_interval", 0);
+                long interval = Long.parseLong(pm.getString("update_interval", "0"));
                 if (interval > 0) {
                     if (interval < current_time - last_check) {
                         new AlarmReceiver().onReceive(context, intent);
                     }
                 }
             }
-        } catch (Exception ignore) {
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.provider.Settings;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.NotificationCompat;
 import android.view.View;
@@ -223,6 +224,10 @@ public class Util {
         notificationBuilder.setContentIntent(contentPendingIntent);
         notificationBuilder.setAutoCancel(true);
         notificationBuilder.setDeleteIntent(deletePendingIntent);
+        if(MainActivity.pm != null) {
+            if(MainActivity.pm.getBoolean("update_sound", false))
+                notificationBuilder.setSound(Settings.System.DEFAULT_NOTIFICATION_URI);
+        }
         ++n;
         //notificationBuilder.setNumber(n); // don't delete this I need this for debugging ~ xtj9182
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
@@ -237,6 +242,10 @@ public class Util {
             notification.flags = Notification.FLAG_NO_CLEAR;
         } else {
             notification.flags = Notification.FLAG_AUTO_CANCEL;
+        }
+        if(MainActivity.pm != null) {
+            if(MainActivity.pm.getBoolean("update_vibrate", false))
+                notification.defaults |= Notification.DEFAULT_VIBRATE;
         }
         notificationManager.notify(id, notification);
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,7 +5,7 @@
     <string name="action_ajustar_a">Anpassen an</string>
     <string name="action_settings">Einstellungen</string>
     <string name="agregado">Manga hinzugefügt</string>
-    <string name="agregadodescarga">Manga zu Downloads hinzugefügt</string>
+    <string name="agregadodescarga">Kapitel zu Downloads hinzugefügt</string>
     <string name="adding_to_db">Füge zur Datenbank hinzu</string>
     <string name="ajuste_alto">An Höhe anpassen</string>
     <string name="ajuste_ancho">An Breite anpassen</string>
@@ -89,7 +89,7 @@
     <string name="new_mangas_found">Neue Mangas gefunden.</string>
     <string name="no_update">Nicht auf Updates überprüfen</string>
     <string name="nodisponible">N/A</string>
-    <string name="notification_sound_subtitle">Bei neu gefundene Mangas.</string>
+    <string name="notification_sound_subtitle">Bei neu gefundener Kapitel</string>
     <string name="notification_sound_title">Ton abspielen</string>
     <string name="rotation">Rotation</string>
     <string name="see_later">Später lesen</string>
@@ -212,4 +212,5 @@
     <string name="show_status_bar_subtitle">Dadurch wird die Status bar beim lesen angezeigt</string>
     <string name="x_of_y_chapters_downloaded">%1$d von %2$d Kapiteln heruntergeladen</string>
     <string name="deleting">Lösche …</string>
+    <string name="dont_spam_redownload_button">Kamerad, mehrmals auf den Button zu drücken wird den Download nicht beschleunigen !</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -42,6 +42,7 @@
     </string-array>
     <string-array name="periodo">
         <item>@string/no_update</item>
+        <item>@string/_update_at_start_up</item>
         <item>@string/_6hours</item>
         <item>@string/_12hours</item>
         <item>@string/_1day</item>
@@ -50,6 +51,7 @@
     </string-array>
     <string-array name="periodo_val">
         <item>0</item>
+        <item>-1</item>
         <item>21600000</item>
         <item>43200000</item>
         <item>86400000</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,9 +5,10 @@
     <string name="_2day">2 days</string>
     <string name="_6hours">6 Hours</string>
     <string name="_7day">7 days</string>
+    <string name="_update_at_start_up">Update at start up</string>
     <string name="action_ajustar_a">Fit to</string>
     <string name="action_settings">Settings</string>
-    <string name="agregadodescarga">Manga added to downloads</string>
+    <string name="agregadodescarga">Chapter added to downloads</string>
     <string name="agregado">Manga added</string>
     <string name="adding_to_db">Adding to database</string>
     <string name="ajuste_alto">Fit to height</string>
@@ -71,7 +72,7 @@
     <string name="nobuscarupdate">Don\'t search for updates</string>
     <string name="nodisponible">N/A</string>
     <string name="no_scale">Original size</string>
-    <string name="notification_sound_subtitle">When new manga are found</string>
+    <string name="notification_sound_subtitle">When new chapters are found</string>
     <string name="notification_sound_title">Play sound</string>
     <string name="no_update">Don\'t check for updates</string>
     <string name="opciones_descarga">Download settings</string>
@@ -131,7 +132,7 @@
     <string name="update_threads_background_summary">Amount of update threads for background: %s</string>
     <string name="update_thread_manual_title">Update threads (Manual)</string>
     <string name="update_threads_manual_summary">Amount of update threads for manual search: %s</string>
-    <string name="download_remain_confirmation">Do you want to download all chapters that are not yet downloaded?</string>
+    <string name="download_remain_confirmation">Do you want to download all remaining chapters?</string>
     <string name="download_unread_confirmation">Do you want to download all unread chapters?</string>
     <string name="mar_and_di">Mark as read and delete images</string>
     <string name="select_begin">Select from the beginning</string>
@@ -221,4 +222,7 @@
     <string name="error_sqlite_exception_while_trying_to_open_db">SQLiteException while trying to open database !</string>
     <string name="error_exception_while_trying_to_open_db">Exception while trying to open database !</string>
     <string name="error_exception_while_trying_to_update_db">Exception while trying to update database !</string>
+    <string name="dont_spam_redownload_button">Please wait for the current image to finish downloading !</string>
+    <string name="one_more_chapter_not_displayed_here">more chapter not displayed here &#8230;</string>
+    <string name="x_more_chapters_not_displayed_here">more chapters not displayed here &#8230;</string>
 </resources>

--- a/app/src/main/res/xml/fragment_preferences.xml
+++ b/app/src/main/res/xml/fragment_preferences.xml
@@ -64,6 +64,11 @@
             android:key="update_sound"
             android:summary="@string/notification_sound_subtitle"
             android:title="@string/notification_sound_title" />
+        <android.support.v7.preference.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="update_vibrate"
+            android:summary="@string/notification_sound_subtitle"
+            android:title="Vibrate (TODO)" />
         <ar.rulosoft.custompref.SeekBarCustomPreference
             android:defaultValue="1"
             android:dialogTitle="@string/update_thread_background_title"

--- a/imageviewtouchlibrary/build.gradle
+++ b/imageviewtouchlibrary/build.gradle
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.2.1'
 }


### PR DESCRIPTION
+ add more db readonly checks
+ show snackbar with chapter name when going to previous chapter
+ speed up "Delete Images", "Reset Chapters" and "Mark selected as ..." functions using multithreading
+ manga update notification changes: when more than 10 chapters are found
we will display 10 chapter titles and trim titles that are longer
than 38 characters, when 10 or less chapters have been found
we will try to show as much of the titles as we can.
+ rework automatic updates (update interval) notifications to be in line with
manual update notifications
+ add option to vibrate when new chapters are found
+ fix minor bug that was causing some code to never
be executed due to an ignored exception
+ instead of hiding the actionbar when
someone spams the redownload button
show a toast instead
+ add wakelock to download pool service
so downloads don't get cancelled while
app is in the background.
(not sure about this, but I would think that we need this)
+ prototype for https://github.com/raulhaag/MiMangaNu/issues/333