### PR TITLE
android automatic refactor recycle

### DIFF
--- a/imageviewtouchlibrary/src/main/java/it/sephiroth/android/library/imagezoom/test/utils/ExifUtils.java
+++ b/imageviewtouchlibrary/src/main/java/it/sephiroth/android/library/imagezoom/test/utils/ExifUtils.java
@@ -151,7 +151,10 @@ public class ExifUtils {
             try {
                 provider = context.getContentResolver().acquireContentProviderClient(uri);
             } catch (SecurityException e) {
-                return 0;
+                if (provider != null) {
+					provider.release();
+				}
+				return 0;
             }
 
             if (provider != null) {
@@ -192,6 +195,9 @@ public class ExifUtils {
                 }
             }
         }
+		if (provider != null) {
+			provider.release();
+		}
         return 0;
     }
 }


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis