### PR TITLE
Add front page to MangaEden sites + Minor Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ android:
     - tools
 
     # The BuildTools version used by your project
-    - build-tools-25.0.1
+    - build-tools-25.0.2
 
     # The SDK version used to compile your project
     - android-25

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "ar.rulosoft.mimanganu"
@@ -46,7 +46,7 @@ android {
 }
 
 dependencies {
-    final ANDROID_SUPPORT = '25.1.0'
+    final ANDROID_SUPPORT = '25.1.1'
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile "com.android.support:support-v4:$ANDROID_SUPPORT"
     compile "com.android.support:design:$ANDROID_SUPPORT"
@@ -58,12 +58,12 @@ dependencies {
     compile 'rapid.decoder:library:0.3.0'
     compile 'rapid.decoder:jpeg-decoder:0.3.0'
     compile 'rapid.decoder:png-decoder:0.3.0'
-    compile 'com.squareup.okhttp3:okhttp:3.4.2'
-    compile 'com.squareup.okio:okio:1.9.0'
+    compile 'com.squareup.okhttp3:okhttp:3.6.0'
+    compile 'com.squareup.okio:okio:1.11.0'
     compile 'com.squareup.duktape:duktape-android:1.1.0'
-    compile 'com.github.franmontiel:PersistentCookieJar:v1.0.0'
-    compile 'ch.acra:acra:4.9.1'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    compile 'com.github.franmontiel:PersistentCookieJar:v1.0.1'
+    compile 'ch.acra:acra:4.9.2'
+    androidTestCompile 'com.android.support:support-annotations:25.1.1'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/DetailsFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/DetailsFragment.java
@@ -38,8 +38,9 @@ public class DetailsFragment extends Fragment {
 
     public static final String TITLE = "titulo_m";
     public static final String PATH = "path_m";
+    public static final String IMG = "img";
     private static final String TAG = "DetailsFragment";
-    private String title, path;
+    private String title, path, img;
     private int id;
     private ImageLoader imageLoader;
     private ControlInfo data;
@@ -55,6 +56,7 @@ public class DetailsFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         title = getArguments().getString(TITLE);
         path = getArguments().getString(PATH);
+        img = getArguments().getString(IMG);
         id = getArguments().getInt(MainFragment.SERVER_ID);
         setHasOptionsMenu(true);
         return inflater.inflate(R.layout.fragment_details, container, false);
@@ -130,6 +132,7 @@ public class DetailsFragment extends Fragment {
             ((MainActivity) getActivity()).setTitle(getResources().getString(R.string.datosde) + " " + title);
         }
         manga = new Manga(id, title, path, false);
+        manga.setImages(img);
         serverBase = ServerBase.getServer(id, getContext());
         imageLoader = new ImageLoader(getContext());
         swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {

--- a/app/src/main/java/ar/rulosoft/mimanganu/MainActivity.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MainActivity.java
@@ -181,6 +181,13 @@ public class MainActivity extends AppCompatActivity {
     public void replaceFragmentAllowStateLoss(Fragment fragment, String tag) {
         backListener = null;
         keyUpListener = null;
+        // introduced in support lib v25.1.0
+        // setAllowOptimization(false)
+        // fA -> fB
+        // fA.onStop -> fB.onStart
+        // setAllowOptimization(true) (new default)
+        // fA -> fB
+        // fB.onStart -> fA.onStop
         getSupportFragmentManager().beginTransaction().setCustomAnimations(R.anim.fade_in, R.anim.fade_out).replace(R.id.coordinator_layout, fragment).addToBackStack(tag).commitAllowingStateLoss();
         getSupportFragmentManager().executePendingTransactions();
     }

--- a/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/MainFragment.java
@@ -393,7 +393,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Main
                             ((MainActivity) getActivity()).replaceFragment(fragment, "FilteredServerList");
                         }
                     } else {
-                        Util.getInstance().showFastSnackBar("This server need login, set account on settings.", getView(), getContext());
+                        Util.getInstance().showFastSnackBar(getString(R.string.this_server_needs_an_account), getView(), getContext());
                     }
                 } else {
                     MangaFolderSelect mangaFolderSelect = new MangaFolderSelect();

--- a/app/src/main/java/ar/rulosoft/mimanganu/ServerFilteredNavigationFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ServerFilteredNavigationFragment.java
@@ -162,7 +162,6 @@ public class ServerFilteredNavigationFragment extends Fragment implements OnLast
         }
     }
 
-
     @Override
     public void onRequestedLastItem() {
         if (serverBase.hasMore && !loading.isShown() && !mStart)
@@ -194,6 +193,7 @@ public class ServerFilteredNavigationFragment extends Fragment implements OnLast
         bundle.putInt(MainFragment.SERVER_ID, serverBase.getServerID());
         bundle.putString(DetailsFragment.TITLE, manga.getTitle());
         bundle.putString(DetailsFragment.PATH, manga.getPath());
+        bundle.putString(DetailsFragment.IMG, manga.getImages());
         DetailsFragment detailsFragment = new DetailsFragment();
         detailsFragment.setArguments(bundle);
         ((MainActivity) getActivity()).replaceFragment(detailsFragment, "DetailsFragment");

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/BatoTo.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/BatoTo.java
@@ -2,9 +2,7 @@ package ar.rulosoft.mimanganu.servers;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.support.v7.preference.PreferenceManager;
-import android.text.Html;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -17,6 +15,7 @@ import ar.rulosoft.mimanganu.R;
 import ar.rulosoft.mimanganu.componentes.Chapter;
 import ar.rulosoft.mimanganu.componentes.Manga;
 import ar.rulosoft.mimanganu.componentes.ServerFilter;
+import ar.rulosoft.mimanganu.utils.Util;
 import ar.rulosoft.navegadores.Navigator;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -99,14 +98,8 @@ class BatoTo extends ServerBase {
         ArrayList<Manga> mangas = new ArrayList<>();
         Pattern p = Pattern.compile("<a href=\"([^\"]+)\">[^>]+(book_open|book).+?>(.+?)<");
         Matcher m = p.matcher(source);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            while (m.find()) {
-                mangas.add(new Manga(getServerID(), Html.fromHtml(m.group(3), Html.FROM_HTML_MODE_LEGACY).toString(), m.group(1), m.group(2).length() == 4));
-            }
-        } else {
-            while (m.find()) {
-                mangas.add(new Manga(getServerID(), Html.fromHtml(m.group(3)).toString(), m.group(1), m.group(2).length() == 4));
-            }
+        while (m.find()) {
+            mangas.add(new Manga(getServerID(), Util.getInstance().fromHtml(m.group(3)).toString(), m.group(1), m.group(2).length() == 4));
         }
         return mangas;
     }
@@ -206,7 +199,7 @@ class BatoTo extends ServerBase {
         nav.addPost("rememberMe", "1");
         nav.post("https://bato.to/forums/index.php?app=core&module=global&section=login&do=process");
         data = getNavigatorAndFlushParameters().get("https://bato.to/myfollows/");
-        return data.contains("-" + user);
+        return data.contains("-" + user.toLowerCase());
     }
 
     @Override

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/DeNineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/DeNineManga.java
@@ -174,7 +174,7 @@ class DeNineManga extends ServerBase {
             web = HOST + orderV[filters[3][0]];
         else
             web = "http://de.ninemanga.com/search/?name_sel=contain&wd=&author_sel=contain&author=&artist_sel=contain&artist=&category_id=" + includedGenres + "&out_category_id=" + excludedGenres + "&completed_series=" + completeV[filters[2][0]] + "&type=high&page=" + pageNumber + ".html";
-        Log.d("NM","web: "+web);
+        //Log.d("NM","web: "+web);
         String source = getNavigatorWithNeededHeader().get(web);
         // regex to generate genre ids: <li id="cate_.+?" cate_id="(.+?)" cur="none" class="cate_list"><label><a class="sub_clk cirmark">(.+?)</a></label></li>
         Pattern pattern = Pattern.compile("<dl class=\"bookinfo\">.+?href=\"(.+?)\"><img src=\"(.+?)\".+?\">(.+?)<");

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/EsNineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/EsNineManga.java
@@ -169,7 +169,7 @@ class EsNineManga extends ServerBase {
             web = HOST + orderV[filters[3][0]];
         else
             web = "http://es.ninemanga.com/search/?name_sel=contain&wd=&author_sel=contain&author=&artist_sel=contain&artist=&category_id=" + includedGenres + "&out_category_id=" + excludedGenres + "&completed_series=" + completeV[filters[2][0]] + "&type=high&page=" + pageNumber + ".html";
-        Log.d("NM","web: "+web);
+        //Log.d("NM","web: "+web);
         String source = getNavigatorWithNeededHeader().get(web);
         Pattern pattern = Pattern.compile("<dl class=\"bookinfo\">.+?href=\"(.+?)\"><img src=\"(.+?)\".+?\">(.+?)<");
         Matcher matcher = pattern.matcher(source);

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ItNineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ItNineManga.java
@@ -173,7 +173,7 @@ class ItNineManga extends ServerBase {
             web = HOST + orderV[filters[3][0]];
         else
             web = "http://it.ninemanga.com/search/?name_sel=contain&wd=&author_sel=contain&author=&artist_sel=contain&artist=&category_id=" + includedGenres + "&out_category_id=" + excludedGenres + "&completed_series=" + completeV[filters[2][0]] + "&type=high&page=" + pageNumber + ".html";
-        Log.d("NM","web: "+web);
+        //Log.d("NM","web: "+web);
         String source = getNavigatorWithNeededHeader().get(web);
         // regex to generate genre ids: <li id="cate_.+?" cate_id="(.+?)" cur="none" class="cate_list"><label><a class="sub_clk cirmark">(.+?)</a></label></li>
         Pattern pattern = Pattern.compile("<dl class=\"bookinfo\">.+?href=\"(.+?)\"><img src=\"(.+?)\".+?\">(.+?)<");

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaEdenIt.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaEdenIt.java
@@ -1,6 +1,7 @@
 package ar.rulosoft.mimanganu.servers;
 
 import android.content.Context;
+import android.util.Log;
 
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -55,11 +56,11 @@ public class MangaEdenIt extends ServerBase {
     };
 
     private static String[] order = new String[]{
-            "Views", "Latest Chapter", "Manga Title", "Chapters"
+            "Front page", "Views", "Latest Chapter", "Manga Title", "Chapters"
     };
 
     private static String[] orderV = new String[]{
-            "&order=1", "&order=3", "&order=-0", "&order=2"
+            "", "&order=1", "&order=3", "&order=-0", "&order=2"
     };
 
     MangaEdenIt(Context context) {
@@ -165,9 +166,24 @@ public class MangaEdenIt extends ServerBase {
         return mangas;
     }
 
-    @Override
-    public FilteredType getFilteredType() {
-        return FilteredType.TEXT;
+    private ArrayList<Manga> getMangasFromFrontpage(String source) {
+        Pattern pattern1 = Pattern.compile("<img src=\"(//cdn\\.mangaeden\\.com/mangasimg/.+?)\".+?<div class=\"hottestInfo\">[\\s]*<a href=\"(/it/it-manga/[^\"<>]+?)\" class=.+?\">(.+?)</a>");
+        Matcher matcher1 = pattern1.matcher(source);
+        ArrayList<Manga> mangas = new ArrayList<>();
+        int i = 0;
+        while (matcher1.find()) {
+            i++;
+            /*Log.d("ME", "(1): " + "http:" + matcher1.group(1));
+            Log.d("ME", "(2): " + matcher1.group(2));
+            Log.d("ME", "(3): " + matcher1.group(3));*/
+            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(matcher1.group(3)).toString(), HOST + matcher1.group(2), false);
+            manga.setImages("http:" + matcher1.group(1));
+            mangas.add(manga);
+            //Log.d("ME", "i: " + i);
+            if (i == 40) //47 43 44
+                break;
+        }
+        return mangas;
     }
 
     @Override
@@ -186,9 +202,15 @@ public class MangaEdenIt extends ServerBase {
         for (int i = 0; i < filters[0].length; i++) {
             web = web + typeV[filters[0][i]];
         }
-        web = web + orderV[filters[4][0]] + "&page=" + pageNumber;
-        String source = getNavigatorAndFlushParameters().get(web);
-        return getMangasFromSource(source);
+        if (orderV[filters[4][0]].equals("")) {
+            web = "http://www.mangaeden.com/it/";
+            String source = getNavigatorAndFlushParameters().get(web);
+            return getMangasFromFrontpage(source);
+        } else {
+            web = web + orderV[filters[4][0]] + "&page=" + pageNumber;
+            String source = getNavigatorAndFlushParameters().get(web);
+            return getMangasFromSource(source);
+        }
     }
 
     @Override

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/NineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/NineManga.java
@@ -70,7 +70,13 @@ class NineManga extends ServerBase {
         Pattern pattern = Pattern.compile("bookname\" href=\"(/manga/[^\"]+)\">(.+?)<");
         Matcher matcher = pattern.matcher(source);
         while (matcher.find()) {
-            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(matcher.group(2)).toString(), HOST + matcher.group(1), false);
+            String title = Util.getInstance().fromHtml(matcher.group(2)).toString();
+            //Log.d("NM","t0: "+title);
+            if (title.equals(title.toUpperCase())) {
+                title = Util.getInstance().toCamelCase(title.toLowerCase());
+                //Log.d("NM","t1: "+title);
+            }
+            Manga manga = new Manga(getServerID(), title, HOST + matcher.group(1), false);
             mangas.add(manga);
         }
         return mangas;
@@ -97,7 +103,7 @@ class NineManga extends ServerBase {
         manga.setAuthor(getFirstMatchDefault("author.+?\">(.+?)<", source, ""));
         // Genre
         manga.setGenre((Util.getInstance().fromHtml(getFirstMatchDefault("<li itemprop=\"genre\".+?</b>(.+?)</li>", source, "").replace("a><a", "a>, <a") + ".").toString().trim()));
-        // Chapter
+        // Chapters
         Pattern p = Pattern.compile("<a class=\"chapter_list_a\" href=\"(/chapter.+?)\" title=\"(.+?)\">(.+?)</a>");
         Matcher matcher = p.matcher(source);
         ArrayList<Chapter> chapters = new ArrayList<>();
@@ -182,14 +188,20 @@ class NineManga extends ServerBase {
             web = HOST + orderV[filters[3][0]];
         else
             web = "http://ninemanga.com/search/?name_sel=contain&wd=&author_sel=contain&author=&artist_sel=contain&artist=&category_id=" + includedGenres + "&out_category_id=" + excludedGenres + "&completed_series=" + completeV[filters[2][0]] + "&type=high&page=" + pageNumber + ".html";
-        Log.d("NM","web: "+web);
+        //Log.d("NM","web: "+web);
         String source = getNavigatorWithNeededHeader().get(web);
         // regex to generate genre ids: <li id="cate_.+?" cate_id="(.+?)" cur="none" class="cate_list"><label><a class="sub_clk cirmark">(.+?)</a></label></li>
         Pattern pattern = Pattern.compile("<dl class=\"bookinfo\">.+?href=\"(.+?)\"><img src=\"(.+?)\".+?\">(.+?)<");
         Matcher matcher = pattern.matcher(source);
         ArrayList<Manga> mangas = new ArrayList<>();
         while (matcher.find()) {
-            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(matcher.group(3)).toString(), HOST + matcher.group(1), false);
+            String title = Util.getInstance().fromHtml(matcher.group(3)).toString();
+            //Log.d("NM","t0: "+title);
+            if (title.equals(title.toUpperCase())) {
+                title = Util.getInstance().toCamelCase(title.toLowerCase());
+                //Log.d("NM","t1: "+title);
+            }
+            Manga manga = new Manga(getServerID(), title, HOST + matcher.group(1), false);
             manga.setImages(matcher.group(2));
             mangas.add(manga);
         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/RuNineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/RuNineManga.java
@@ -1,7 +1,6 @@
 package ar.rulosoft.mimanganu.servers;
 
 import android.content.Context;
-import android.util.Log;
 
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -178,7 +177,7 @@ class RuNineManga extends ServerBase {
             web = HOST + orderV[filters[3][0]];
         else
             web = "http://ru.ninemanga.com/search/?name_sel=contain&wd=&author_sel=contain&author=&artist_sel=contain&artist=&category_id=" + includedGenres + "&out_category_id=" + excludedGenres + "&completed_series=" + completeV[filters[2][0]] + "&type=high&page=" + pageNumber + ".html";
-        Log.d("NM","web: "+web);
+        //Log.d("NM","web: "+web);
         String source = getNavigatorWithNeededHeader().get(web);
         // regex to generate genre ids: <li id="cate_.+?" cate_id="(.+?)" cur="none" class="cate_list"><label><a class="sub_clk cirmark">(.+?)</a></label></li>
         Pattern pattern = Pattern.compile("<dl class=\"bookinfo\">.+?href=\"(.+?)\"><img src=\"(.+?)\".+?\">(.+?)<");

--- a/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/utils/Util.java
@@ -36,6 +36,10 @@ public class Util {
     private Util() {
     }
 
+    private static class LazyHolder {
+        private static final Util utilInstance = new Util();
+    }
+
     public static Util getInstance() {
         return LazyHolder.utilInstance;
     }
@@ -185,6 +189,8 @@ public class Util {
             public void run() {
                 if (context != null)
                     Toast.makeText(context, toast, Toast.LENGTH_LONG).show();
+                else
+                    Log.e("Util", "Failed to deliver toast! Context was null. Message was: " + toast);
             }
         });
     }
@@ -196,6 +202,8 @@ public class Util {
             public void run() {
                 if (context != null)
                     Toast.makeText(context, toast, length).show();
+                else
+                    Log.e("Util", "Failed to deliver toast! Context was null. Message was: " + toast);
             }
         });
     }
@@ -404,8 +412,19 @@ public class Util {
         return columnSize;
     }
 
-    private static class LazyHolder {
-        private static final Util utilInstance = new Util();
+    public String toCamelCase(String input) {
+        StringBuilder camelCase = new StringBuilder();
+        boolean nextCamelCase = true;
+        for (char c : input.toCharArray()) {
+            if (!Character.isLetterOrDigit(c) && c != '\'') { //Character.isSpaceChar(c)
+                nextCamelCase = true;
+            } else if (nextCamelCase) {
+                c = Character.toTitleCase(c);
+                nextCamelCase = false;
+            }
+            camelCase.append(c);
+        }
+        return camelCase.toString();
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,5 +249,6 @@
     <string name="reset">Reset</string>
     <string name="login">Login</string>
     <string name="accounts">Accounts</string>
+    <string name="this_server_needs_an_account">This server needs a login. Set an account in the settings.</string>
 
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/imageviewtouchlibrary/build.gradle
+++ b/imageviewtouchlibrary/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 14
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:appcompat-v7:25.1.1'
 }


### PR DESCRIPTION
+ batoto: fix testlogin fail for users that have Uppercase letters in their username (prototype for: https://github.com/raulhaag/MiMangaNu/issues/392)
+ batoto: refactor a Html.fromHtml to use Util's fromHtml method which already has a builtin Nougat check
+ ninemanga (en): CamelCase UPPERCASE manga titles
+ mangaeden sites: add Front page as order and make it the new default.
(Mangaeden has no thumbnails in the normal directory view
BUT they do have thumbnails on their Front page. Keep in mind that when including genres
you need to switch order to not be front page)
+ minor fix: don't throw away saved img string in detailsfragment
(in most cases this string is overwritten but it might be
useful to keep it for some new sources. Basically when thumbnail = Cover Image
we can use this img variable, instead of having a regex re-detect data we already have.)
+ Bump all outdated Libraries to the latest version