### PR TITLE
improve batoto chapters language selection

### DIFF
--- a/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/PreferencesFragment.java
@@ -1,5 +1,8 @@
 package ar.rulosoft.mimanganu;
 
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -17,7 +20,11 @@ import android.support.v7.preference.PreferenceManager;
 import android.support.v7.preference.SwitchPreferenceCompat;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
 
 import com.fedorvlasov.lazylist.FileCache;
 
@@ -244,6 +251,49 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
 
                 if(time < 0)
                     MainActivity.coldStart = false;
+
+                return true;
+            }
+        });
+
+        /** This is for Custom language selection */
+        final ListPreference listPrefBatotoLang = (ListPreference) getPreferenceManager().findPreference("batoto_lang_selection");
+        listPrefBatotoLang.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                if (newValue.equals("Custom")) {
+                    LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+                    View rootView = inflater.inflate(R.layout.batoto_custom_lang_dialog, null);
+                    final EditText CustomLang = (EditText) rootView.findViewById(R.id.txtCustomLang);
+                    AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getContext());
+                    dialogBuilder.setTitle("Custom language");
+                    dialogBuilder.setView(rootView);
+                    dialogBuilder.setPositiveButton("Ok", null);
+                    dialogBuilder.setNegativeButton("Cancel", null);
+                    AlertDialog dialog = dialogBuilder.create();
+                    dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+                        @Override
+                        public void onShow(final DialogInterface dialog) {
+                            Button accept = ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE);
+                            accept.setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View view) {
+                                    prefs.edit().putString("batoto_custom_lang", CustomLang.getText().toString()).apply();
+                                    Util.getInstance().toast(getContext(), "Custom Language: " + CustomLang.getText().toString());
+                                    dialog.dismiss();
+                                }
+                            });
+                            Button cancel = ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_NEGATIVE);
+                            cancel.setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View view) {
+                                    dialog.dismiss();
+                                }
+                            });
+                        }
+                    });
+                    dialog.show();
+                }
 
                 return true;
             }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/BatoTo.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/BatoTo.java
@@ -151,13 +151,19 @@ class BatoTo extends ServerBase {
                 Pattern pattern = Pattern.compile("<a href=\"([^\"]+)\" title=\"[^\"]+\">.+?>([^<]+).+?title=\"(.+?)\".+?<a[^>]+>([^<]+)");
                 data = getFirstMatchDefault("ipb_table chapters_list\"([\\s\\S]+?)</table", data, "");
                 Matcher matcher = pattern.matcher(data);
-                boolean batoto_lang = prefs.getBoolean("batoto_lang", false);
-                String lang = Locale.getDefault().getDisplayLanguage();
+                String lang_selection, lang = "";
+                lang_selection = prefs.getString("batoto_lang_selection", "Automatic");
+                if (lang_selection.equals("Automatic"))
+                    lang = Locale.getDefault().getDisplayLanguage();
+                else if (lang_selection.equals("Custom"))
+                    lang = prefs.getString("batoto_custom_lang", "");
+                else
+                    lang = lang_selection;
                 while (matcher.find()) {
-                    if (batoto_lang && !lang.isEmpty()) {
+                    if (!lang_selection.equals("All") && !lang.isEmpty()) {
                         if (matcher.group(3).contains(lang))
                             chapters.add(0, new Chapter("(" + matcher.group(3) + ") " + matcher.group(2) + " [" + matcher.group(4) + "]", matcher.group(1)));
-                    } else
+                    } else if (lang_selection.equals("All"))
                         chapters.add(0, new Chapter("(" + matcher.group(3) + ") " + matcher.group(2) + " [" + matcher.group(4) + "]", matcher.group(1)));
                 }
                 manga.setChapters(chapters);

--- a/app/src/main/java/ar/rulosoft/mimanganu/services/DownloadPoolService.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/services/DownloadPoolService.java
@@ -391,6 +391,8 @@ public class DownloadPoolService extends Service implements StateChangeListener 
                     ChapterDownload d = chapterDownloads.get(idx);
                     idx++;
                     // start notification code
+                    if (n > chapterDownloads.size())
+                        n = idx;
                     if (n < idx)
                         n = idx;
                     if (resetN) {

--- a/app/src/main/res/layout/batoto_custom_lang_dialog.xml
+++ b/app/src/main/res/layout/batoto_custom_lang_dialog.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="300dp"
+    android:layout_height="match_parent"
+    android:layout_gravity="center"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingLeft="10dp"
+    android:paddingRight="10dp"
+    android:paddingTop="10dp">
+
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="" />
+
+    <EditText
+        android:id="@+id/txtCustomLang"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <requestFocus />
+    </EditText>
+
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+    </RelativeLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -233,6 +233,6 @@
     <string name="multi_import_title">Mehrfaches importieren</string>
     <string name="multi_import_subtitle">Werden Manga mit FromFolder importiert, werden alle darin vorhandenen Ordner hinzugefügt.</string>
     <string name="this_server_needs_an_account">Diese Seite benötigt einen Account. Siehe die Account Einstellungen.</string>
-    <string name="native_chapters_title">Füge nur native Kapitel hinzu</string>
-    <string name="native_chapters_subtitle">Nur Kapitel die der Sprache des Gerätes entsprechen werden von Batoto hinzugefügt</string>
+    <string name="batoto_lang_chapters_title">Batoto Kapitel Sprache</string>
+    <string name="batoto_lang_chapters_subtitle">Nur Kapitel die der ausgewählten Sprache entsprechen werden von Batoto hinzugefügt. Auswahl: %s</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -64,4 +64,17 @@
         <item>172800000</item>
         <item>604800000</item>
     </string-array>
+    <string-array name="batoto_lang_array">
+        <item>Automatic</item>
+        <item>All</item>
+        <item>Custom</item>
+        <item>English</item>
+        <item>Spanish</item>
+        <item>German</item>
+        <item>French</item>
+        <item>Italian</item>
+        <item>Russian</item>
+        <item>Japanese</item>
+        <item>Chinese</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,8 +250,8 @@
     <string name="login">Login</string>
     <string name="accounts">Accounts</string>
     <string name="this_server_needs_an_account">This server needs a login. Set an account in the settings.</string>
-    <string name="batoto_settings">Batoto Settings</string>
-    <string name="native_chapters_title">Only add native chapters</string>
-    <string name="native_chapters_subtitle">Only chapters from this device\'s language will be added from Batoto</string>
+    <string name="extra_server_settings">Extra Server Settings</string>
+    <string name="batoto_lang_chapters_title">Batoto chapters language</string>
+    <string name="batoto_lang_chapters_subtitle">Batoto: Only chapters in the selected language will be added. Selection: %s</string>
 
 </resources>

--- a/app/src/main/res/xml/fragment_preferences.xml
+++ b/app/src/main/res/xml/fragment_preferences.xml
@@ -17,12 +17,15 @@
         android:key="account"
         android:title="@string/accounts" />
 
-    <PreferenceCategory android:title="@string/batoto_settings">
-        <android.support.v7.preference.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="batoto_lang"
-            android:summary="@string/native_chapters_subtitle"
-            android:title="@string/native_chapters_title" />
+    <PreferenceCategory android:title="@string/extra_server_settings">
+        <ListPreference
+            android:defaultValue="Automatic"
+            android:dialogTitle="@string/batoto_lang_chapters_title"
+            android:entries="@array/batoto_lang_array"
+            android:entryValues="@array/batoto_lang_array"
+            android:key="batoto_lang_selection"
+            android:summary="@string/batoto_lang_chapters_subtitle"
+            android:title="@string/batoto_lang_chapters_title" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/connection_settings">


### PR DESCRIPTION
+ improve batoto chapters language selection
+ also fix a rare bug
in rare cases a download would error out cause
our resolveOverCF function could get triggered in
cases where it shouldn't. Instead of returning null
here we simply give back the response so we
can handle a bad response that triggers our
cloudflare resolver even thought it shouldn't

initially I was a little confused since I only wanted to add 
a small selection of languages but I guess having the
option to manually type in any obscure language that
one wants is a good idea so I added this too.