### PR TITLE
More translation stuff and additional message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /local.properties
 /.idea/workspace.xml
 /.idea/libraries
+/.idea/dictionaries
 .DS_Store
 /build
 /captures

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/Chapter.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/Chapter.java
@@ -90,6 +90,7 @@ public class Chapter {
 
     @Override
     public boolean equals(Object obj) {
+        // FIXME chapter comparison uses URL/path - might break if sites transition from HTTP to HTTPS
         return (obj instanceof Chapter) && this.path.equalsIgnoreCase(((Chapter) obj).path);
     }
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/FromFolder.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/FromFolder.java
@@ -67,6 +67,7 @@ public class FromFolder extends ServerBase {
             chapter.setDownloaded(true);
             chapters.add(chapter);
         }
+        Chapter.Comparators.setManga_title(manga.getTitle());
         Collections.sort(chapters,Chapter.Comparators.NUMBERS_ASC);
         manga.setChapters(chapters);
     }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaHere.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaHere.java
@@ -87,7 +87,7 @@ public class MangaHere extends ServerBase {
             Pattern p = Pattern.compile(PATTERN_CAPITULOS);
             Matcher m = p.matcher(data);
             while (m.find()) {
-                Chapter mc = new Chapter(Util.getInstance().fromHtml(m.group(2)).toString().trim(), m.group(1));
+                Chapter mc = new Chapter(Util.getInstance().fromHtml(m.group(2)).toString().trim(), "http:" + m.group(1));
                 mc.addChapterFirst(manga);
             }
         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -262,6 +262,7 @@ public abstract class ServerBase {
             this.loadMangaInformation(manga, true);
             this.loadChapters(manga, false);
         } catch (Exception e) {
+            Util.getInstance().toast(context, context.getResources().getString(R.string.update_search_failed, mangaDb.getTitle(), getServerName()));
             e.printStackTrace();
             return 0;
         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -464,10 +464,7 @@ public abstract class ServerBase {
                 for (int i = simpleListSize - 1; i > -1; i--) {
                     if (simpleListSize > 10 && n == x) { // last element if 10+ chapters
                         int tmp = simpleListSize - x;
-                        if (tmp == 1)
-                            largeContentText = largeContentText + tmp + " " + context.getString(R.string.one_more_chapter_not_displayed_here);
-                        else
-                            largeContentText = largeContentText + tmp + " " + context.getString(R.string.x_more_chapters_not_displayed_here);
+                        largeContentText += context.getResources().getQuantityString(R.plurals.more_chapters_not_displayed_here, tmp, tmp);
                     } else if (simpleListSize <= 10 && n == x) { // last element if <= 10 chapters
                         largeContentText = largeContentText + simpleList.get(i).getTitle();
                     } else { // every element that isn't the last element
@@ -489,11 +486,8 @@ public abstract class ServerBase {
                 Intent intent = new Intent(context, MainActivity.class);
                 intent.putExtra("manga_id", simpleList.get(0).getMangaID());
                 intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                if (simpleListSize > 1) {
-                    Util.getInstance().createNotification(context, false, (int) System.currentTimeMillis(), intent, simpleListSize + " " + context.getResources().getString(R.string.new_chapters, manga.getTitle()), largeContentText);
-                } else {
-                    Util.getInstance().createNotification(context, false, (int) System.currentTimeMillis(), intent, simpleListSize + " " + context.getResources().getString(R.string.new_chapter, manga.getTitle()), largeContentText);
-                }
+
+                Util.getInstance().createNotification(context, false, (int) System.currentTimeMillis(), intent, context.getResources().getQuantityString(R.plurals.new_chapter, simpleListSize, simpleListSize, manga.getTitle()), largeContentText);
             }
             return null;
         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -146,8 +146,8 @@
     <string name="retry">Wiederholen</string>
     <string name="sort_number">Kapitelnummer (abstg.)</string>
     <string name="sort_number_asc">Kapitelnummer (aufstg.)</string>
-    <string name="delete_confirm">Das/diese Kapitel wirklich löschen?</string>
-    <string name="storage_permission_denied">Die Berechtigung für den Speicherzugriff wird benötigt, damit MiMangaNu korrekt funktionieren kann.</string>
+    <string name="delete_confirm">Kapitel wirklich löschen?</string>
+    <string name="storage_permission_denied">Die Berechtigung für den Speicherzugriff wird benötigt damit MiMangaNu korrekt funktionieren kann.</string>
     <string name="no_new_updates_found">Keine neuen Kapitel gefunden :(</string>
     <string name="sort_as_added_to_db_asc">Wie in DB hinzugefügt (aufstg.)</string>
     <string name="sort_as_added_to_db_desc">Wie in DB hinzugefügt (abstg.)</string>
@@ -162,10 +162,10 @@
     <string name="deleted">Gelöscht: %s</string>
     <string name="deleted_no_var">Gelöscht</string>
     <string name="clear_cache_title">Cache löschen</string>
-    <string name="clear_cache_subtitle">Löscht den Cache. Alle Cover Bilder müssen danach erneut heruntergeladen werden.</string>
+    <string name="clear_cache_subtitle">Löscht den Cache. Cover Bilder müssen danach erneut heruntergeladen werden.</string>
     <string name="misc_settings">Sonstige Einstellungen</string>
     <string name="seamless_chapter_transitions_delete_read_title">Lösche nach Übergang</string>
-    <string name="seamless_chapter_transitions_delete_read_subtitle">Löscht das aktuelle Kapitel, sobald das nächste Kapitel begonnen wird.</string>
+    <string name="seamless_chapter_transitions_delete_read_subtitle">Löscht das aktuelle Kapitel sobald das nächste Kapitel begonnen wird.</string>
     <string name="new_chapter">Neues Kapitel von %s</string>
     <string name="new_chapters">Neue Kapitel von %s</string>
     <string name="dir_already_on_db">Verzeichnis bereits hinzugefügt</string>
@@ -186,7 +186,7 @@
     <string name="include_finished_manga_title">Beendete Manga einbeziehen</string>
     <string name="include_finished_manga_subtitle">Es werden auch bereits beendete Manga bei der Update-Suche mit einbezogen. Sonst werden nur laufende Manga berücksichtigt.</string>
     <string name="hide_sensitivity_scrollbar_title">Ausblenden der Empfindlichkeits-Scrollbar</string>
-    <string name="hide_sensitivity_scrollbar_subtitle">Die Empfindlichkeit-Scrollbar wird ausgeblendet, wenn nicht im Vollbild-Modus gelesen wird.</string>
+    <string name="hide_sensitivity_scrollbar_subtitle">Die Empfindlichkeit-Scrollbar wird ausgeblendet wenn nicht im Vollbild-Modus gelesen wird.</string>
     <string name="add">Hinzufügen</string>
     <string name="fast_update_title">Schnelles Update</string>
     <string name="fast_update_subtitle">Vergleiche nur die neuesten 20 Kapitel vom Server.</string>
@@ -203,7 +203,7 @@
     <string name="show_status_bar_title">Einblenden des Statusbalkens</string>
     <string name="show_status_bar_subtitle">Der Statusbalken wird beim Lesen eingeblendet.</string>
     <string name="hide_actionbar_title">Ausblenden des Aktionsbalkens</string>
-    <string name="hide_actionbar_subtitle">Der Aktionsbalken wird ausgeblendet, wenn nicht im Vollbild-Modus gelesen wird.</string>
+    <string name="hide_actionbar_subtitle">Der Aktionsbalken wird ausgeblendet wenn nicht im Vollbild-Modus gelesen wird.</string>
     <string name="marking_as_read">Markiere als gelesen …</string>
     <string name="marking_as_unread">Markiere als ungelesen …</string>
     <string name="deleting">Lösche …</string>
@@ -213,8 +213,8 @@
     <string name="error_while_trying_to_open_db">Fehler beim Öffnen der Datenbank!</string>
     <string name="error_while_trying_to_update_db">Fehler beim Aktualisieren der Datenbank!</string>
     <string name="dont_spam_redownload_button">Mehrmals auf die Taste drücken macht den Download nicht schneller.</string>
-    <string name="one_more_chapter_not_displayed_here">weiteres Kapitel nicht angezeigt …</string>
-    <string name="x_more_chapters_not_displayed_here">weitere Kapitel nicht angezeigt …</string>
+    <string name="one_more_chapter_not_displayed_here">weiteres Kapitel hier nicht angezeigt …</string>
+    <string name="x_more_chapters_not_displayed_here">weitere Kapitel hier nicht angezeigt …</string>
     <string name="vibrate">Vibrieren</string>
     <string name="thanks">Danke</string>
     <string name="_update_at_start_up_6hours">Update beim Start wenn 6 Stunden vergangen sind</string>
@@ -225,7 +225,7 @@
     <string name="multi_import_title">Mehrfaches Importieren</string>
     <string name="multi_import_subtitle">Beim Import über FromFolder, werden alle im Importpfad enthaltenen Ordner als eigenständiges Manga hinzugefügt.</string>
     <string name="auto_import_title">Importiere Manga automatisch</string>
-    <string name="auto_import_subtitle">Importiere Ordner automatisch vom angegebenen Pfad, sobald der reguläre Aktualisierungsprozess abgeschlossen ist.</string>
+    <string name="auto_import_subtitle">Importiere Ordner automatisch vom angegebenen Pfad sobald der reguläre Aktualisierungsprozess abgeschlossen ist.</string>
     <string name="auto_import_path_title">Pfad für automatischen Import</string>
     <string name="auto_import_path_subtitle">Importiere Ordner automatisch vom angegebenen Pfad als Manga.</string>
     <string name="chapter_download_errors">Kapitel Download Fehler:</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -16,7 +16,6 @@
     <string name="ajuste_ancho">An Breite anpassen</string>
     <string name="ajuste_imagen">Standard Bildanpassung</string>
     <string name="apachelic">Apache Lizenz</string>
-    <string name="app_name">Mi Manga Nu</string>
     <string name="autor">Autor</string>
     <string name="borrado_imagenes">Bilder gelöscht</string>
     <string name="borrarcap">Lösche Kapitel</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -166,8 +166,6 @@
     <string name="misc_settings">Sonstige Einstellungen</string>
     <string name="seamless_chapter_transitions_delete_read_title">Lösche nach Übergang</string>
     <string name="seamless_chapter_transitions_delete_read_subtitle">Löscht das aktuelle Kapitel sobald das nächste Kapitel begonnen wird.</string>
-    <string name="new_chapter">Neues Kapitel von %s</string>
-    <string name="new_chapters">Neue Kapitel von %s</string>
     <string name="dir_already_on_db">Verzeichnis bereits hinzugefügt</string>
     <string name="already_on_db">Manga bereits hinzugefügt</string>
     <string name="edit_server_list">Serverliste bearbeiten</string>
@@ -213,8 +211,6 @@
     <string name="error_while_trying_to_open_db">Fehler beim Öffnen der Datenbank!</string>
     <string name="error_while_trying_to_update_db">Fehler beim Aktualisieren der Datenbank!</string>
     <string name="dont_spam_redownload_button">Mehrmals auf die Taste drücken macht den Download nicht schneller.</string>
-    <string name="one_more_chapter_not_displayed_here">weiteres Kapitel hier nicht angezeigt …</string>
-    <string name="x_more_chapters_not_displayed_here">weitere Kapitel hier nicht angezeigt …</string>
     <string name="vibrate">Vibrieren</string>
     <string name="thanks">Danke</string>
     <string name="_update_at_start_up_6hours">Update beim Start wenn 6 Stunden vergangen sind</string>
@@ -276,4 +272,12 @@
     <string name="batoto_lang_japanese">Japanisch</string>
     <string name="batoto_lang_chinese">Chinesisch</string>
     <string name="update_search_failed">Suche nach neuen Kapiteln für %1$s auf %2$s fehlgeschlagen.</string>
+    <plurals name="more_chapters_not_displayed_here">
+        <item quantity="one">%d weiteres Kapitel wird hier nicht angezeigt…</item>
+        <item quantity="other">%d weitere Kapitel werden hier nicht angezeigt…</item>
+    </plurals>
+    <plurals name="new_chapter">
+        <item quantity="one">%1$d neues Kapitel von %2$s</item>
+        <item quantity="other">%1$d neue Kapitel von %2$s</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -276,4 +276,5 @@
     <string name="batoto_lang_russian">Russisch</string>
     <string name="batoto_lang_japanese">Japanisch</string>
     <string name="batoto_lang_chinese">Chinesisch</string>
+    <string name="update_search_failed">Suche nach neuen Kapiteln für %1$s auf %2$s fehlgeschlagen.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -154,7 +154,6 @@
     <string name="sort_as_added_to_db_desc">As added to db (desc)</string>
     <string name="download_next_chapter_automatically_subtitle">Bajar capítulo siguiente automaticamente</string>
     <string name="download_next_chapter_automatically_title">Bajar capítulo siguiente</string>
-    <string name="new_chapter">Nuevo capítulo de %s</string>
     <string name="already_on_db">El manga ya estaba agregado</string>
     <string name="dir_already_on_db">El directorio ya estaba agregado</string>
     <string name="edit_server_list">Editar lista de servidores</string>
@@ -184,7 +183,6 @@
     <string name="add">Agregar</string>
     <string name="fast_update_title">Actualizaciones rápidas</string>
     <string name="fast_update_subtitle">Solo compara los últimos 20 capítulos</string>
-    <string name="new_chapters">Nuevo capítulos de %s</string>
     <string name="searching">Búsqueda para \"%s\" en</string>
     <string name="chapters">capítulos</string>
     <string name="cancel">Cancelar</string>
@@ -211,9 +209,7 @@
     <string name="_update_at_start_up_1day">Buscar actualizaciones al iniciar si paso 1 día</string>
     <string name="_update_at_start_up_6hours">Buscar actualizaciones al iniciar si pasaron 6 horas</string>
     <string name="dont_spam_redownload_button">Aun descargando, espera a que termine</string>
-    <string name="one_more_chapter_not_displayed_here">y un capítulo que no pudo ser mostrado &#8230;</string>
     <string name="vibrate">Vibrar</string>
-    <string name="x_more_chapters_not_displayed_here">y más capítulos que no pudieron ser mostrados &#8230;</string>
     <string name="adding_folders_as_mangas">Agragar carpetas como Mangas</string>
     <string name="auto_import_path_subtitle">Auto impotar mangas del directorio seleccionado</string>
     <string name="auto_import_path_title">Ruta al directorio para importar</string>
@@ -264,5 +260,12 @@
     <string name="deleted_no_var">Borrar</string>
     <string name="disable_internet_detection_title">Desactivar deteccion de estado de internet.</string>
     <string name="disable_internet_detection_subtitle">Para dispositivos en los que esta cause problemas.</string>
+    <plurals name="more_chapters_not_displayed_here">
+        <item quantity="one">%d y más capítulos que no pudieron ser mostrados…</item>
+        <item quantity="other">%d y un capítulo que no pudo ser mostrado…</item>
+    </plurals>
+    <plurals name="new_chapter">
+        <item quantity="one">%1$d nuevo capítulo de %2$s</item>
+        <item quantity="other">%1$d nuevo capítulos de %2$s</item>
+    </plurals>
 </resources>
-

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="update_message">Cambios en v1.68:\n\t* Arreglado TusMangasOnline.\n\t* Mejorado el uso de memoria.</string>
-    <string name="app_name">Mi Manga Nu</string>
     <string name="action_ajustar_a">Ajustar a</string>
     <string name="descargas">Descargas</string>
     <string name="datosde">Datos de </string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -169,7 +169,6 @@
     <string name="reset_server_list_to_defaults_subtitle">Cela affichera tous les serveurs</string>
     <string name="no_wifi_connection">Pas de connexion WiFi</string>
     <string name="no_internet_connection">Pas de connexion Internet</string>
-    <string name="new_chapter">Nouveau chapitre de %s</string>
     <string name="misc_settings">Paramètres Divers</string>
     <string name="edit_server_list">Modifier la liste des serveurs</string>
     <string name="downloading">Téléchargement: </string>
@@ -183,7 +182,6 @@
     <string name="add">Ajouter</string>
     <string name="fast_update_title">Mises à jour rapides</string>
     <string name="fast_update_subtitle">Seulement comparer dernier 20 chapitre du serveur</string>
-    <string name="new_chapters">Nouveaux chapitres de %s</string>
     <string name="chapters">Chapitres</string>
     <string name="cancel">Annuler</string>
     <string name="deleting_empty_directories">Suppression de répertoires vides …</string>
@@ -193,4 +191,8 @@
     <string name="searching">A la recherche de \"%s\" sont</string>
     <string name="delete_confirm">Etes-vous sûr de supprimer ces chapitres?</string>
     <string name="thanks">remerciements</string>
+    <plurals name="new_chapter">
+        <item quantity="one">%1$d nouveau chapitre de %2$s</item>
+        <item quantity="other">%1$d nouveaux chapitres de %2$s</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Mi Manga Nu</string>
     <string name="action_ajustar_a">Ajuster</string>
     <string name="descargas">Téléchargements</string>
     <string name="datosde">Détails</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <string name="action_ajustar_a">Adatta</string>
     <string name="descargas">Scaricati</string>
     <string name="datosde">Dettagli</string>
@@ -170,7 +169,6 @@
     <string name="reset_server_list_to_defaults_subtitle">In questo modo visualizzare tutti i server</string>
     <string name="no_wifi_connection">Nessuna connessione WiFi</string>
     <string name="no_internet_connection">Nessuna connessione Internet</string>
-    <string name="new_chapter">Nuovo capitolo di %s</string>
     <string name="misc_settings">Impostazioni varie</string>
     <string name="edit_server_list">Modifica elenco dei server</string>
     <string name="downloading">Scaricando: </string>
@@ -184,7 +182,6 @@
     <string name="add">Aggiungere</string>
     <string name="fast_update_title">Aggiornamenti veloci</string>
     <string name="fast_update_subtitle">Confrontare solo lo scorso 20 capitolo dal server</string>
-    <string name="new_chapters">Nuovi capitoli di %s</string>
     <string name="chapters">capitoli</string>
     <string name="cancel">annullare</string>
     <string name="deleting_empty_directories">Eliminazione directory vuote …</string>
@@ -194,4 +191,8 @@
     <string name="searching">Ricerca di \"%s\" sono</string>
     <string name="delete_confirm">Sei sicuro di voler eliminare questi capitoli?</string>
     <string name="thanks">Ringraziamenti</string>
+    <plurals name="new_chapter">
+        <item quantity="one">%1$d nuovo capitolo di %2$s</item>
+        <item quantity="other">%1$d nuovi capitoli di %2$s</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">Mi Manga Nu</string>
     <string name="action_ajustar_a">Adatta</string>
     <string name="descargas">Scaricati</string>
     <string name="datosde">Dettagli</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Mi Manga Nu</string>
     <string name="State_New">Новый</string>
     <string name="_12hours">12 Часов</string>
     <string name="_1day">1 день</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -169,7 +169,6 @@
     <string name="reset_server_list_to_defaults_title">Сброс списка серверов по умолчанию</string>
     <string name="no_wifi_connection">Нет подключения к Wi-Fi</string>
     <string name="no_internet_connection">Нет соединения с интернетом</string>
-    <string name="new_chapter">Новая глава %s</string>
     <string name="misc_settings">Настройки Разное</string>
     <string name="edit_server_list">Редактирование списка серверов</string>
     <string name="downloading">Скачивание: </string>
@@ -183,7 +182,6 @@
     <string name="add">Добавить</string>
     <string name="fast_update_subtitle">Только сравните последние 20 главу из сервера</string>
     <string name="fast_update_title">Быстрые обновления</string>
-    <string name="new_chapters">Новые Главы %s</string>
     <string name="chapters">главы</string>
     <string name="cancel">отменить</string>
     <string name="deleting_empty_directories">Удаление пустых каталогов …</string>
@@ -193,4 +191,8 @@
     <string name="searching">Поиск \"%s\2 являются</string>
     <string name="delete_confirm">Вы уверены, чтобы удалить эти разделы?</string>
     <string name="thanks">Благодарности</string>
+    <plurals name="new_chapter">
+        <item quantity="one">%1$d Новая глава %2$s</item>
+        <item quantity="other">%1$d Новые Главы %2$s</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,4 +276,5 @@
     <string name="batoto_lang_russian">Russian</string>
     <string name="batoto_lang_japanese">Japanese</string>
     <string name="batoto_lang_chinese">Chinese</string>
+    <string name="update_search_failed">Failed to search for new chapters of %1$s on %2$s.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="ajuste_ancho">Fit to width</string>
     <string name="ajuste_imagen">Image fit by default</string>
     <string name="apachelic">Apache License</string>
-    <string name="app_name">Mi Manga Nu</string>
+    <string name="app_name" translatable="false">Mi Manga Nu</string>
     <string name="autor">Author</string>
     <string name="borrado_imagenes">Images deleted</string>
     <string name="borrarcap">Remove chapter</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,8 +167,6 @@
     <string name="misc_settings">Misc Settings</string>
     <string name="seamless_chapter_transitions_delete_read_title">Delete after reading</string>
     <string name="seamless_chapter_transitions_delete_read_subtitle">This deletes the current chapter when transitioning to the next chapter</string>
-    <string name="new_chapter">New Chapter of %s</string>
-    <string name="new_chapters">New Chapters of %s</string>
     <string name="dir_already_on_db">Directory already added</string>
     <string name="already_on_db">Manga already added</string>
     <string name="edit_server_list">Edit server list</string>
@@ -214,8 +212,6 @@
     <string name="error_while_trying_to_open_db">Error while trying to open database!</string>
     <string name="error_while_trying_to_update_db">Error while trying to update database!</string>
     <string name="dont_spam_redownload_button">Please wait for the current image to finish downloading!</string>
-    <string name="one_more_chapter_not_displayed_here">more chapter not displayed here &#8230;</string>
-    <string name="x_more_chapters_not_displayed_here">more chapters not displayed here &#8230;</string>
     <string name="vibrate">Vibrate</string>
     <string name="thanks">Thanks</string>
     <string name="_update_at_start_up_6hours">Update at start up if 6 hours have passed</string>
@@ -277,4 +273,12 @@
     <string name="batoto_lang_japanese">Japanese</string>
     <string name="batoto_lang_chinese">Chinese</string>
     <string name="update_search_failed">Failed to search for new chapters of %1$s on %2$s.</string>
+    <plurals name="more_chapters_not_displayed_here">
+        <item quantity="one">%d more chapter not displayed here…</item>
+        <item quantity="other">%d more chapters not displayed here…</item>
+    </plurals>
+    <plurals name="new_chapter">
+        <item quantity="one">%1$d new chapter of %2$s</item>
+        <item quantity="other">%1$d new chapters of %2$s</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
I have added an informative message to ServerBase in case a search for new chapters fails. This is currently the case, as MangaHere seems to have updated their SSL certificate but something is lacking in their certificate chain.

Checking https://www.mangahere.co with https://www.digicert.com/help/ yields the following text:

> SSL Certificate is not trusted
>
>The certificate is not signed by a trusted authority (checking against Mozilla's root store). If you bought the certificate from a trusted authority, you probably just need to install one or more Intermediate certificates. Contact your certificate provider for assistance doing this for your server platform.

This in turn throws a `java.security.cert.CertPathValidatorException` and makes the search fail. This becomes obvious by the stack dump when trying to search for Manga on MangaHere currently. Maybe this could also be changed to make the hint nicer?

@raulhaag The current case might bring up the question how to handle such hosts, as surely people will complain about this - even though the problem is with the server, not with MiMangaNu...

Furthermore I have changed four strings to plurals for improved translatability and also set the app name to untranslatable.