### PR TITLE
Follow-up of #461

### DIFF
--- a/app/src/main/java/ar/rulosoft/mimanganu/ServerFilteredNavigationFragment.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/ServerFilteredNavigationFragment.java
@@ -207,12 +207,16 @@ public class ServerFilteredNavigationFragment extends Fragment implements OnLast
         inflater.inflate(R.menu.manga_server_visual, menu);
         MenuItem search = menu.findItem(R.id.action_search);
         if (!serverBase.hasList()) {
-            MenuItem vcl = menu.findItem(R.id.ver_como_lista);
-            vcl.setVisible(false);
+            MenuItem item = menu.findItem(R.id.ver_como_lista);
+            item.setVisible(false);
         }
         if (serverBase.getServerFilters().length == 0) {
-            MenuItem flt = menu.findItem(R.id.filter);
-            flt.setVisible(false);
+            MenuItem item = menu.findItem(R.id.filter);
+            item.setVisible(false);
+        }
+        if (!serverBase.hasSearch()) {
+            MenuItem item = menu.findItem(R.id.action_search);
+            item.setVisible(false);
         }
         SearchView searchView = (SearchView) MenuItemCompat.getActionView(search);
         searchView.setOnQueryTextListener(new OnQueryTextListener() {

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/Chapter.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/Chapter.java
@@ -1,6 +1,7 @@
 package ar.rulosoft.mimanganu.componentes;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 
 import java.io.File;
 import java.util.Comparator;
@@ -117,6 +118,7 @@ public class Chapter {
         this.downloaded = downloaded;
     }
 
+    @Nullable
     public String getExtra() {
         return extra;
     }

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/Chapter.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/Chapter.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 
 import ar.rulosoft.mimanganu.servers.FromFolder;
 import ar.rulosoft.mimanganu.servers.ServerBase;
+import ar.rulosoft.mimanganu.utils.HtmlUnescape;
 import ar.rulosoft.mimanganu.utils.Paths;
 import ar.rulosoft.mimanganu.utils.Util;
 
@@ -32,7 +33,7 @@ public class Chapter {
 
     public Chapter(String title, String path) {
         super();
-        this.title = Util.getInstance().fromHtml(title).toString();
+        this.title = HtmlUnescape.Unescape(Util.getInstance().fromHtml(title).toString().trim());
         this.path = path;
     }
 
@@ -65,7 +66,7 @@ public class Chapter {
     }
 
     public void setTitle(String title) {
-        this.title = title;
+        this.title = HtmlUnescape.Unescape(Util.getInstance().fromHtml(title).toString().trim());
     }
 
     public String getPath() {
@@ -205,7 +206,7 @@ public class Chapter {
     public static class Comparators {
         private static final String FLOAT_PATTERN = "([.,0123456789]+)";
         private static final String STRING_END_PATTERN = "[^\\d]\\.";
-        private static final String VOLUME_REMOVE_PATTERN = "[v|V][o|O][l|L].{0,1}\\d+";
+        private static final String VOLUME_REMOVE_PATTERN = "[v|V][o|O][l|L].?\\d+";
         public static Comparator<Chapter> TITLE_DESC = new Comparator<Chapter>() {
             @Override
             public int compare(Chapter c1, Chapter c2) {

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/Manga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/Manga.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 import java.util.ArrayList;
 
 import ar.rulosoft.mimanganu.utils.HtmlUnescape;
+import ar.rulosoft.mimanganu.utils.Util;
 
 public class Manga {
     private int id;
@@ -29,26 +30,28 @@ public class Manga {
     public Manga(int serverId, String title, String path, boolean finished) {
         super();
         this.serverId = serverId;
-        this.title = title;
         this.path = path;
         this.author = "";
         this.genre = "";
         this.finished = finished;
+
+        setTitle(title);
     }
 
-    public Manga(int serverId, int id, String title, String synopsis, String images, String path, String author, boolean finished, float scrollSentive, int readingDirection, int lastIndex, int news) {
+    public Manga(int serverId, int id, String title, String synopsis, String images, String path, String author, boolean finished, float scrollSensitive, int readingDirection, int lastIndex, int news) {
         this.serverId = serverId;
         this.id = id;
-        this.title = title;
-        this.synopsis = synopsis;
         this.images = images;
         this.path = path;
-        this.author = author;
         this.finished = finished;
-        this.scrollSensitive = scrollSentive;
+        this.scrollSensitive = scrollSensitive;
         this.readingDirection = readingDirection;
         this.lastIndex = lastIndex;
         this.news = news;
+
+        setTitle(title);
+        setAuthor(author);
+        setSynopsis(synopsis);
     }
 
     public int getId() {
@@ -72,7 +75,7 @@ public class Manga {
     }
 
     public void setTitle(String title) {
-        this.title = title;
+        this.title = HtmlUnescape.Unescape(Util.getInstance().fromHtml(title).toString().trim());
     }
 
     public String getSynopsis() {
@@ -80,7 +83,7 @@ public class Manga {
     }
 
     public void setSynopsis(String synopsis) {
-        this.synopsis = HtmlUnescape.Unescape(synopsis);
+        this.synopsis = HtmlUnescape.Unescape(Util.getInstance().fromHtml(synopsis).toString().trim());
     }
 
     @Nullable
@@ -105,7 +108,7 @@ public class Manga {
     }
 
     public void setAuthor(String author) {
-        this.author = author;
+        this.author = HtmlUnescape.Unescape(Util.getInstance().fromHtml(author).toString().trim());
     }
 
     @Override
@@ -142,6 +145,7 @@ public class Manga {
         return news;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public void setNews(int news) {
         this.news = news;
     }
@@ -150,6 +154,7 @@ public class Manga {
         return lastIndex;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public void setLastIndex(int lastIndex) {
         this.lastIndex = lastIndex;
     }
@@ -174,6 +179,7 @@ public class Manga {
         return scrollSensitive;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public void setScrollSensitive(float scrollSensitive) {
         this.scrollSensitive = scrollSensitive;
     }
@@ -183,7 +189,7 @@ public class Manga {
     }
 
     public void setGenre(String genre) {
-        this.genre = genre;
+        this.genre = HtmlUnescape.Unescape(Util.getInstance().fromHtml(genre).toString().trim());
     }
 
     public int getReaderType(){
@@ -194,6 +200,7 @@ public class Manga {
         this.readerType = readerType;
     }
 
+    @Nullable
     public String getLastUpdate() {
         return lastUpdate;
     }

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/Manga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/Manga.java
@@ -189,7 +189,9 @@ public class Manga {
     }
 
     public void setGenre(String genre) {
-        this.genre = HtmlUnescape.Unescape(Util.getInstance().fromHtml(genre).toString().trim());
+        this.genre = HtmlUnescape.Unescape(
+                Util.getInstance().fromHtml(genre)
+                        .toString().trim().replaceAll("\\s+,\\s+", ", "));
     }
 
     public int getReaderType(){

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/DeNineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/DeNineManga.java
@@ -8,7 +8,7 @@ class DeNineManga extends NineManga {
     private static final String HOST = "http://de.ninemanga.com";
 
     private static final String PATTERN_IMAGE =
-            "src=\"(http://pic\\.wiemanga\\.com/comics/pic/[^\"]+?)\"";
+            "src=\"(https://img\\.wiemanga\\.com/comics/pic/[^\"]+?)\"";
 
     private static final int[] fltGenre = {
             R.string.flt_tag_adventure,

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/FromFolder.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/FromFolder.java
@@ -40,10 +40,10 @@ public class FromFolder extends ServerBase {
 
     FromFolder(Context context) {
         super(context);
-        this.setFlag(R.drawable.noimage);
-        this.setIcon(R.drawable.from_folder);
-        this.setServerName("FromFolder");
-        setServerID(ServerBase.FROMFOLDER);
+        setFlag(R.drawable.noimage);
+        setIcon(R.drawable.from_folder);
+        setServerName("FromFolder");
+        setServerID(FROMFOLDER);
     }
 
     @Override
@@ -62,19 +62,19 @@ public class FromFolder extends ServerBase {
         ArrayList<String> folders = Util.getInstance().dirList(manga.getPath());
         ArrayList<Chapter> chapters = new ArrayList<>();
         folders.remove(0);//remove "."
-        for(String folder:folders){
-            Chapter chapter = new Chapter(folder,manga.getPath() + folder + "/");
+        for (String folder : folders) {
+            Chapter chapter = new Chapter(folder, manga.getPath() + folder + "/");
             chapter.setDownloaded(true);
             chapters.add(chapter);
         }
         Chapter.Comparators.setManga_title(manga.getTitle());
-        Collections.sort(chapters,Chapter.Comparators.NUMBERS_ASC);
+        Collections.sort(chapters, Chapter.Comparators.NUMBERS_ASC);
         manga.setChapters(chapters);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        loadChapters(manga,forceReload);
+        loadChapters(manga, forceReload);
         manga.setFinished(true);
     }
 
@@ -92,9 +92,9 @@ public class FromFolder extends ServerBase {
     public void chapterInit(Chapter chapter) throws Exception {
         ArrayList<String> images = Util.getInstance().imageList(chapter.getPath());
         chapter.setPages(images.size());
-        Collections.sort(images,NUMBERS_ASC);
+        Collections.sort(images, NUMBERS_ASC);
         String save = "";
-        for (String image:images){
+        for (String image : images) {
             save = save + "|" + image;
         }
         chapter.setExtra(save);

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ItNineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ItNineManga.java
@@ -8,7 +8,7 @@ class ItNineManga extends NineManga {
     private static final String HOST = "http://it.ninemanga.com";
 
     private static final String PATTERN_IMAGE =
-            "src=\"(http://img\\.it\\.ninemanga\\.com/it_manga/[^\"]+?)\"";
+            "src=\"(http://esnm\\.ninemanga\\.com/it_manga/[^\"]+?)\"";
 
     private static int[] fltGenre = {
             R.string.flt_tag_action,

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/JapScan.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/JapScan.java
@@ -16,25 +16,21 @@ import ar.rulosoft.mimanganu.utils.Util;
 /**
  * Created by xtj-9182 on 21.02.2017.
  */
-
 class JapScan extends ServerBase {
 
-    public static String HOST = "http://www.japscan.com";
-
-    private static String[] order = new String[]{
-            "All"
-    };
-
-    private static String[] orderV = new String[]{
-            ""
-    };
+    private static final String HOST = "http://www.japscan.com";
 
     JapScan(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_fr);
-        this.setIcon(R.drawable.japscan);
-        this.setServerName("JapScan");
-        setServerID(ServerBase.JAPSCAN);
+        setFlag(R.drawable.flag_fr);
+        setIcon(R.drawable.japscan);
+        setServerName("JapScan");
+        setServerID(JAPSCAN);
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
     }
 
     @Override
@@ -59,40 +55,37 @@ class JapScan extends ServerBase {
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters() == null || manga.getChapters().size() == 0 || forceReload)
-            loadMangaInformation(manga, forceReload);
+        loadMangaInformation(manga, forceReload);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        String source = getNavigatorAndFlushParameters().get(manga.getPath());
+        if (manga.getChapters().isEmpty() || forceReload) {
+            String source = getNavigatorAndFlushParameters().get(manga.getPath());
 
-        // Cover Image
-        // JapScan has no cover images ...
+            // Cover Image
+            // JapScan has no cover images ...
 
-        // Summary
-        String summary = getFirstMatchDefault("<div id=\"synopsis\">(.+?)</div>", source, defaultSynopsis);
-        manga.setSynopsis(Util.getInstance().fromHtml(summary).toString());
+            // Summary
+            manga.setSynopsis(getFirstMatchDefault("<div id=\"synopsis\">(.+?)</div>", source, context.getString(R.string.nodisponible)));
 
-        // Status
-        manga.setFinished(!getFirstMatchDefault("<div class=\"row\">.+?<div class=\"cell\">.+?<div class=\"cell\">.+?<div class=\"cell\">.+?<div class=\"cell\">.+?<div class=\"cell\">(.+?)</div>", source, "").contains("En Cours"));
+            // Status
+            manga.setFinished(!getFirstMatchDefault("<div class=\"row\">.+?<div class=\"cell\">.+?<div class=\"cell\">.+?<div class=\"cell\">.+?<div class=\"cell\">.+?<div class=\"cell\">(.+?)</div>", source, "").contains("En Cours"));
 
-        // Author
-        manga.setAuthor(Util.getInstance().fromHtml(getFirstMatchDefault("<div class=\"row\">(.+?)</div>", source, "")).toString().trim());
+            // Author
+            manga.setAuthor(getFirstMatchDefault("<div class=\"row\">(.+?)</div>", source, context.getString(R.string.nodisponible)));
 
-        // Genres
-        manga.setGenre((Util.getInstance().fromHtml(getFirstMatchDefault("<div class=\"row\">.+?<div class=\"cell\">.+?<div class=\"cell\">.+?<div class=\"cell\">(.+?)</div>", source, "")).toString().trim()));
+            // Genres
+            manga.setGenre(getFirstMatchDefault("<div class=\"row\">.+?<div class=\"cell\">.+?<div class=\"cell\">.+?<div class=\"cell\">(.+?)</div>", source, context.getString(R.string.nodisponible)));
 
-        // Chapters
-        Pattern pattern = Pattern.compile("<a href=\"(//www\\.japscan\\.com/lecture-en-ligne/[^\"]+?)\">(Scan.+?)</a>", Pattern.DOTALL);
-        Matcher matcher = pattern.matcher(source);
-        ArrayList<Chapter> chapters = new ArrayList<>();
-        while (matcher.find()) {
-            /*Log.d("JS", "1: " + "http:" + matcher.group(1));
-            Log.d("JS", "2: " + matcher.group(2));*/
-            chapters.add(0, new Chapter(Util.getInstance().fromHtml(matcher.group(2)).toString(), "http:" + matcher.group(1)));
+            // Chapters
+            Pattern pattern = Pattern.compile("<a href=\"(//www\\.japscan\\.com/lecture-en-ligne/[^\"]+?)\">(Scan.+?)</a>", Pattern.DOTALL);
+            Matcher matcher = pattern.matcher(source);
+            while (matcher.find()) {
+                Chapter chapter = new Chapter(matcher.group(2), "http:" + matcher.group(1));
+                chapter.addChapterFirst(manga);
+            }
         }
-        manga.setChapters(chapters);
     }
 
     @Override
@@ -102,25 +95,15 @@ class JapScan extends ServerBase {
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
-        //Log.d("JS", "source: " + chapter.getPath() + page + ".html");
         String source = getNavigatorAndFlushParameters().get(chapter.getPath() + page + ".html");
-        String img = "";
-        try {
-            img = getFirstMatchDefault("src=\"(http://cdn[^\"]+)", source, "Error getting image");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        //Log.d("JS", "img: " + img);
-        return img;
+        return getFirstMatchDefault("src=\"(http://cdn[^\"]+)", source, "Error: failed to locate page image link");
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
         String source = getNavigatorAndFlushParameters().get(chapter.getPath());
-        //Log.d("JS", "p: " + chapter.getPath());
-        String pagenumber = getFirstMatchDefault("Page (\\d+)</option>[\\s]*</select>", source, "failed to get the number of pages");
-        //Log.d("JS", "pa: " + pagenumber);
-        chapter.setPages(Integer.parseInt(pagenumber));
+        String pages = getFirstMatchDefault("Page (\\d+)</option>[\\s]*</select>", source, "Error: failed to get the number of pages");
+        chapter.setPages(Integer.parseInt(pages));
     }
 
     private ArrayList<Manga> getMangasFromSource(String source) {
@@ -128,8 +111,6 @@ class JapScan extends ServerBase {
         Matcher matcher = pattern.matcher(source);
         ArrayList<Manga> mangas = new ArrayList<>();
         while (matcher.find()) {
-            /*Log.d("JS", "1: " + matcher.group(1));
-            Log.d("JS", "2: " + matcher.group(2));*/
             Manga manga = new Manga(getServerID(), matcher.group(2), HOST +  matcher.group(1), false);
             mangas.add(manga);
         }
@@ -143,24 +124,7 @@ class JapScan extends ServerBase {
 
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
-        String web = HOST;
-        if (orderV[filters[0][0]].equals("")) {
-            web = "http://www.japscan.com/mangas/";
-        }
-        //Log.d("JS","web: "+web);
-        String source = getNavigatorAndFlushParameters().get(web);
+        String source = getNavigatorAndFlushParameters().get(HOST + "/mangas/");
         return getMangasFromSource(source);
-    }
-
-    @Override
-    public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{
-                new ServerFilter("Order", order, ServerFilter.FilterType.SINGLE)
-        };
-    }
-
-    @Override
-    public boolean hasList() {
-        return false;
     }
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/KissManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/KissManga.java
@@ -16,37 +16,130 @@ import ar.rulosoft.mimanganu.utils.Util;
 import ar.rulosoft.navegadores.Navigator;
 
 class KissManga extends ServerBase {
+    private static final String HOST = "http://kissmanga.com";
 
     private static final String PATTERN_CHAPTER =
             "<td>[\\s]*<a[\\s]*href=\"(/Manga/[^\"]+)\"[\\s]*title=\"[^\"]+\">([^\"]+)</a>[\\s]*</td>";
     private static final String PATTERN_SEARCH =
             "href=\"(/Manga/.*?)\">([^<]+)</a>[^<]+<p>[^<]+<span class=\"info\"";
-    private static final String IP = "93.174.95.110";
-    private static final String HOST = "kissmanga.com";
-    private static final String PAGE_BASE = "http://kissmanga.com/";
-    private static final String[] genre = new String[]{
-            "Action", "Adult", "Adventure", "Comedy",
-            "Comic", "Cooking", "Doujinshi", "Drama",
-            "Ecchi", "Fantasy", "Gender Bender", "Harem",
-            "Historical", "Horror", "Josei", "Lolicon",
-            "Manga", "Manhua", "Manhwa", "Martial Arts",
-            "Mature", "Mecha", "Medical", "Music",
-            "Mystery", "One shot", "Psychological", "Romance",
-            "School Life", "Sci-fi", "Seinen", "Shotacon",
-            "Shoujo", "Shoujo Ai", "Shounen", "Shounen Ai",
-            "Slice of Life", "Smut", "Sports", "Supernatural",
-            "Tragedy", "Webtoon", "Yaoi", "Yuri"
+
+    private static final int[] fltGenre = {
+            R.string.flt_tag_action,
+            R.string.flt_tag_adult,
+            R.string.flt_tag_adventure,
+            R.string.flt_tag_comedy,
+            R.string.flt_tag_comic,
+            R.string.flt_tag_cooking,
+            R.string.flt_tag_doujinshi,
+            R.string.flt_tag_drama,
+            R.string.flt_tag_ecchi,
+            R.string.flt_tag_fantasy,
+            R.string.flt_tag_gender_bender,
+            R.string.flt_tag_harem,
+            R.string.flt_tag_historical,
+            R.string.flt_tag_horror,
+            R.string.flt_tag_josei,
+            R.string.flt_tag_lolicon,
+            R.string.flt_tag_manga,
+            R.string.flt_tag_manhua,
+            R.string.flt_tag_manhwa,
+            R.string.flt_tag_martial_arts,
+            R.string.flt_tag_mature,
+            R.string.flt_tag_mecha,
+            R.string.flt_tag_medical,
+            R.string.flt_tag_music,
+            R.string.flt_tag_mystery,
+            R.string.flt_tag_one_shot,
+            R.string.flt_tag_psychological,
+            R.string.flt_tag_romance,
+            R.string.flt_tag_school_life,
+            R.string.flt_tag_sci_fi,
+            R.string.flt_tag_seinen,
+            R.string.flt_tag_shotacon,
+            R.string.flt_tag_shoujo,
+            R.string.flt_tag_shoujo_ai,
+            R.string.flt_tag_shounen,
+            R.string.flt_tag_shounen_ai,
+            R.string.flt_tag_slice_of_life,
+            R.string.flt_tag_smut,
+            R.string.flt_tag_sports,
+            R.string.flt_tag_supernatural,
+            R.string.flt_tag_tragedy,
+            R.string.flt_tag_webtoon,
+            R.string.flt_tag_yaoi,
+            R.string.flt_tag_yuri,
     };
-    private static String genreVV = "/Genre/";
-    private static String[] order = {"Popularity", "Latest Update", "New Manga", "a-z"};
-    private static String[] orderV = new String[]{"/MostPopular", "/LatestUpdate", "/Newest", ""};
+    private static final String[] valGenre = {
+            "Action",
+            "Adult",
+            "Adventure",
+            "Comedy",
+            "Comic",
+            "Cooking",
+            "Doujinshi",
+            "Drama",
+            "Ecchi",
+            "Fantasy",
+            "Gender-Bender",
+            "Harem",
+            "Historical",
+            "Horror",
+            "Josei",
+            "Lolicon",
+            "Manga",
+            "Manhua",
+            "Manhwa",
+            "Martial-Arts",
+            "Mature",
+            "Mecha",
+            "Medical",
+            "Music",
+            "Mystery",
+            "One-shot",
+            "Psychological",
+            "Romance",
+            "School-Life",
+            "Sci-fi",
+            "Seinen",
+            "Shotacon",
+            "Shoujo",
+            "Shoujo-Ai",
+            "Shounen",
+            "Shounen-Ai",
+            "Slice-of-Life",
+            "Smut",
+            "Sports",
+            "Supernatural",
+            "Tragedy",
+            "Webtoon",
+            "Yaoi",
+            "Yuri"
+    };
+
+    private static final int[] fltOrder = {
+            R.string.flt_order_rating,
+            R.string.flt_order_last_update,
+            R.string.flt_order_newest,
+            R.string.flt_order_alpha
+    };
+    private static final String[] valOrder = {
+            "/MostPopular",
+            "/LatestUpdate",
+            "/Newest",
+            ""
+    };
 
     KissManga(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_en);
-        this.setIcon(R.drawable.kissmanga_icon);
-        this.setServerName("KissManga");
-        setServerID(ServerBase.KISSMANGA);
+        setFlag(R.drawable.flag_en);
+        setIcon(R.drawable.kissmanga_icon);
+        setServerName("KissManga");
+        setServerID(KISSMANGA);
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
     }
 
     @Override
@@ -63,7 +156,7 @@ class KissManga extends ServerBase {
         nav.addPost("status", "");
         nav.addPost("genres", "");
 
-        String source = nav.post(PAGE_BASE + "/AdvanceSearch");
+        String source = nav.post(HOST + "/AdvanceSearch");
 
         ArrayList<Manga> searchList;
         Pattern p = Pattern.compile(PATTERN_SEARCH, Pattern.DOTALL);
@@ -80,42 +173,40 @@ class KissManga extends ServerBase {
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters() == null || manga.getChapters().size() == 0 ||
-                forceReload) loadMangaInformation(manga, forceReload);
+        loadMangaInformation(manga, forceReload);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        String source = getNavigatorAndFlushParameters().get(PAGE_BASE + manga.getPath());
+        if (manga.getChapters().isEmpty() || forceReload) {
+            String source = getNavigatorAndFlushParameters().get(HOST + manga.getPath());
 
-        // Summary
-        manga.setSynopsis(Util.getInstance().fromHtml(getFirstMatchDefault(
-                "<span " + "class=\"info\">Summary:</span>(.+?)</div>", source,
-                defaultSynopsis)).toString());
+            // Summary
+            manga.setSynopsis(
+                    getFirstMatchDefault("<span " + "class=\"info\">Summary:</span>(.+?)</div>", source,
+                    context.getString(R.string.nodisponible)));
 
-        // Cover Image
-        String pictures = getFirstMatchDefault(
-                "rel=\"image_src\" href=\"(.+?)" + "\"", source, null);
-        if (pictures != null) {
-            manga.setImages(pictures);
+            // Cover Image
+            manga.setImages(
+                    getFirstMatchDefault("rel=\"image_src\" href=\"(.+?)" + "\"", source, ""));
+
+            // Author
+            manga.setAuthor(getFirstMatchDefault("Author:(.+?)</p>", source, context.getString(R.string.nodisponible)));
+
+            // Genre
+            manga.setGenre(getFirstMatchDefault("Genres:(.+?)</p>", source, context.getString(R.string.nodisponible)));
+
+            // Status
+            manga.setFinished(getFirstMatchDefault("Status:</span>&nbsp;([\\S]+)", source, "Ongoing").length() == 9);
+
+            // Chapter
+            Pattern p = Pattern.compile(PATTERN_CHAPTER, Pattern.DOTALL);
+            Matcher matcher = p.matcher(source);
+            while (matcher.find()) {
+                Chapter chapter = new Chapter(matcher.group(2).replace(" Read Online", ""), matcher.group(1));
+                chapter.addChapterFirst(manga);
+            }
         }
-
-        // Author
-        manga.setAuthor(Util.getInstance().fromHtml(getFirstMatchDefault("Author:(.+?)</p>", source, "")).toString().replaceAll("^\\s+", "").trim());
-
-        // Genre
-        manga.setGenre(Util.getInstance().fromHtml(getFirstMatchDefault("Genres:(.+?)</p>", source, "")).toString().replaceAll("^\\s+", "").trim());
-
-        manga.setFinished(getFirstMatchDefault("Status:</span>&nbsp;([\\S]+)", source, "Ongoing").length() == 9);
-
-        // Chapter
-        Pattern p = Pattern.compile(PATTERN_CHAPTER, Pattern.DOTALL);
-        Matcher matcher = p.matcher(source);
-        ArrayList<Chapter> chapters = new ArrayList<>();
-        while (matcher.find()) {
-            chapters.add(0, new Chapter(matcher.group(2).replace(" Read Online", ""), matcher.group(1)));
-        }
-        manga.setChapters(chapters);
     }
 
     @Override
@@ -131,13 +222,12 @@ class KissManga extends ServerBase {
         return chapter.getExtra().split("\\|")[page];
     }
 
-    public void setExtra(Chapter chapter) throws Exception{
+    public void setExtra(Chapter chapter) throws Exception {
         int pages = 0;
-        String source = getNavigatorAndFlushParameters().get(PAGE_BASE + chapter.getPath().replaceAll("[^!-z]+", ""));
-        String ca = getNavigatorAndFlushParameters().get(PAGE_BASE + "/Scripts/ca.js");
-        String lo = getNavigatorAndFlushParameters().get(PAGE_BASE + "/Scripts/lo.js");
-        Duktape duktape = Duktape.create();
-        try {
+        String source = getNavigatorAndFlushParameters().get(HOST + chapter.getPath().replaceAll("[^!-z]+", ""));
+        String ca = getNavigatorAndFlushParameters().get(HOST + "/Scripts/ca.js");
+        String lo = getNavigatorAndFlushParameters().get(HOST + "/Scripts/lo.js");
+        try (Duktape duktape = Duktape.create()) {
             duktape.evaluate(ca);
             duktape.evaluate(lo);
             Pattern p = Pattern.compile("javascript\">(.+?)<", Pattern.DOTALL);
@@ -158,8 +248,6 @@ class KissManga extends ServerBase {
                 images = images + "|" + image;
             }
             chapter.setExtra(images);
-        } finally {
-            duktape.close();
         }
         chapter.setPages(pages);
     }
@@ -173,12 +261,10 @@ class KissManga extends ServerBase {
 
     private ArrayList<Manga> getMangasSource(String source) {
         ArrayList<Manga> mangas = new ArrayList<>();
-        Pattern p =
-                Pattern.compile("(https?:[^&|\"]+.ploads/.tc[^&|\"]+).+?href=.+?(/.anga[^&|\"]+).+?>(.+?)<", Pattern.DOTALL);
+        Pattern p = Pattern.compile("(https?:[^&|\"]+.ploads/.tc[^&|\"]+).+?href=.+?(/.anga[^&|\"]+).+?>(.+?)<", Pattern.DOTALL);
         Matcher m = p.matcher(source);
         while (m.find()) {
-            Manga manga =
-                    new Manga(KISSMANGA, m.group(3), m.group(2), false);
+            Manga manga = new Manga(KISSMANGA, m.group(3), m.group(2), false);
             manga.setImages(m.group(1));
             mangas.add(manga);
         }
@@ -186,15 +272,18 @@ class KissManga extends ServerBase {
     }
 
     @Override
-    public boolean hasList() {
-        return false;
-    }
-
-    @Override
     public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{new ServerFilter("Included Genre(s) (multiple no order)", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Excluded Genre(s) (multiple no order)", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Order (only applied on single genre selection)", order, ServerFilter.FilterType.SINGLE)};
+        return new ServerFilter[]{
+                new ServerFilter(
+                        context.getString(R.string.flt_include_tags),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_exclude_tags),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_order),
+                        buildTranslatedStringArray(fltOrder), ServerFilter.FilterType.SINGLE)
+        };
     }
 
     @Override
@@ -202,16 +291,16 @@ class KissManga extends ServerBase {
         if (filters[0].length == 0 && filters[1].length == 0) { // on first load
             return getMangasFiltered(0, 0, pageNumber);
         } else if (filters[0].length == 1) { // single genre selection
-            String web = genreVV + genre[0].replaceAll(" ", "-") + orderV[0];
-            for (int i = 0; i < genre.length; i++) {
+            String web = "/Genre/" + valGenre[0] + valOrder[0];
+            for (int i = 0; i < valGenre.length; i++) {
                 if (Util.getInstance().contains(filters[0], i)) {
-                    web = genreVV + genre[i].replaceAll(" ", "-") + orderV[filters[2][0]];
+                    web = "/Genre/" + valGenre[i] + valOrder[filters[2][0]];
                     if (pageNumber > 1) {
                         web = web + "?page=" + pageNumber;
                     }
                 }
             }
-            String source = getNavigatorAndFlushParameters().post(PAGE_BASE + web);
+            String source = getNavigatorAndFlushParameters().post(HOST + web);
             return getMangasSource(source);
         } else {
             // multiple genre selection
@@ -221,7 +310,7 @@ class KissManga extends ServerBase {
                 Navigator nav = getNavigatorAndFlushParameters();
                 nav.addPost("mangaName", "");
                 nav.addPost("authorArtist", "");
-                for (int i = 0; i < genre.length; i++) {
+                for (int i = 0; i < valGenre.length; i++) {
                     if (Util.getInstance().contains(filters[0], i)) {
                         nav.addPost("genres", "1");
                     } else if (Util.getInstance().contains(filters[1], i)) {
@@ -230,8 +319,8 @@ class KissManga extends ServerBase {
                         nav.addPost("genres", "0");
                     }
                 }
-                nav.addPost("status", ""); //stateV[filters[1][0]])
-                String source = nav.post(PAGE_BASE + "/AdvanceSearch");
+                nav.addPost("status", "");
+                String source = nav.post(HOST + "/AdvanceSearch");
                 return getMangasSource(source);
             }
         }
@@ -244,11 +333,11 @@ class KissManga extends ServerBase {
     }
 
     public ArrayList<Manga> getMangasFiltered(int category, int order, int pageNumber) throws Exception {
-        String web = genreVV + genre[category].replaceAll(" ", "-") + orderV[order];
+        String web = "/Genre/" + valGenre[category] + valOrder[order];
         if (pageNumber > 1) {
             web = web + "?page=" + pageNumber;
         }
-        String source = getNavigatorAndFlushParameters().post(PAGE_BASE + web);
+        String source = getNavigatorAndFlushParameters().post(HOST + web);
         return getMangasSource(source);
     }
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/Kumanga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/Kumanga.java
@@ -3,9 +3,9 @@ package ar.rulosoft.mimanganu.servers;
 import android.content.Context;
 
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -14,76 +14,153 @@ import ar.rulosoft.mimanganu.R;
 import ar.rulosoft.mimanganu.componentes.Chapter;
 import ar.rulosoft.mimanganu.componentes.Manga;
 import ar.rulosoft.mimanganu.componentes.ServerFilter;
-import ar.rulosoft.mimanganu.utils.Util;
 import ar.rulosoft.navegadores.Navigator;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 
 /**
  * Created by Raúl on 23/06/2017.
- * <p>
  * pd: no te enojes koneko
  */
+class Kumanga extends ServerBase {
 
-public class Kumanga extends ServerBase {
+    private static final String HOST = "http://www.kumanga.com/";
 
-    public static String HOST = "http://www.kumanga.com/";
-
-    private static final String[] genre = {
-            "Acción", "Artes marciales", "Automóviles", "Aventura", "Ciencia Ficción",
-            "Comedia", "Demonios", "Deportes", "Doujinshi", "Drama", "Ecchi", "Espacio exterior",
-            "Fantasía", "Gender bender", "Gore", "Harem", "Hentai", "Histórico", "Horror", "Josei",
-            "Juegos", "Locura", "Magia", "Mecha", "Militar", "Misterio", "Música", "Niños",
-            "Parodia", "Policía", "Psicológico", "Recuentos de la vida", "Romance", "Samurai",
-            "Seinen", "Shoujo", "Shoujo Ai", "Shounen", "Shounen Ai", "Sobrenatural",
-            "Súperpoderes", "Suspenso", "Terror", "Tragedia", "Vampiros", "Vida escolar", "Yaoi",
-            "Yuri"
+    private static final int[] fltGenre = {
+            R.string.flt_tag_action, //Acción
+            R.string.flt_tag_martial_arts, //Artes marciales
+            R.string.flt_tag_automobiles, //Automóviles
+            R.string.flt_tag_adventure, //Aventura
+            R.string.flt_tag_sci_fi, //Ciencia Ficción
+            R.string.flt_tag_comedy, //Comedia
+            R.string.flt_tag_daemons, //Demonios
+            R.string.flt_tag_sports, //Deportes
+            R.string.flt_tag_doujinshi, //Doujinshi
+            R.string.flt_tag_drama, //Drama
+            R.string.flt_tag_ecchi, //Ecchi
+            R.string.flt_tag_outer_space, //Espacio exterior
+            R.string.flt_tag_fantasy, //Fantasía
+            R.string.flt_tag_gender_bender, //Gender bender
+            R.string.flt_tag_gore, //Gore
+            R.string.flt_tag_harem, //Harem
+            R.string.flt_tag_hentai, //Hentai
+            R.string.flt_tag_historical, //Histórico
+            R.string.flt_tag_horror, //Horror
+            R.string.flt_tag_josei, //Josei
+            R.string.flt_tag_game, //Juegos
+            R.string.flt_tag_madness, //Locura
+            R.string.flt_tag_magic, //Magia
+            R.string.flt_tag_mecha, //Mecha
+            R.string.flt_tag_military, //Militar
+            R.string.flt_tag_mystery, //Misterio
+            R.string.flt_tag_music, //Música
+            R.string.flt_tag_kodomo, //Niños
+            R.string.flt_tag_parody, //Parodia
+            R.string.flt_tag_police, //Policía
+            R.string.flt_tag_psychological, //Psicológico
+            R.string.flt_tag_slice_of_life, //Recuentos de la vida
+            R.string.flt_tag_romance, //Romance
+            R.string.flt_tag_samurai, //Samurai
+            R.string.flt_tag_seinen, //Seinen
+            R.string.flt_tag_shoujo, //Shoujo
+            R.string.flt_tag_shoujo_ai, //Shoujo Ai
+            R.string.flt_tag_shounen, //Shounen
+            R.string.flt_tag_shounen_ai, //Shounen Ai
+            R.string.flt_tag_supernatural, //Sobrenatural
+            R.string.flt_tag_super_powers, //Súperpoderes
+            R.string.flt_tag_suspense, //Suspenso
+            R.string.flt_tag_terror, //Terror
+            R.string.flt_tag_tragedy, //Tragedia
+            R.string.flt_tag_vampire, //Vampiros
+            R.string.flt_tag_school_life, //Vida escolar
+            R.string.flt_tag_yaoi, //Yaoi
+            R.string.flt_tag_yuri, //Yuri
     };
 
-    private static final String[] genreV = {
-            "&category_filter%5B1%5D=1", "&category_filter%5B2%5D=2", "&category_filter%5B3%5D=3",
-            "&category_filter%5B4%5D=4", "&category_filter%5B5%5D=5", "&category_filter%5B6%5D=6",
-            "&category_filter%5B7%5D=7", "&category_filter%5B8%5D=8", "&category_filter%5B9%5D=9",
-            "&category_filter%5B10%5D=10", "&category_filter%5B11%5D=11",
-            "&category_filter%5B12%5D=12", "&category_filter%5B13%5D=13",
-            "&category_filter%5B14%5D=14", "&category_filter%5B46%5D=46",
-            "&category_filter%5B15%5D=15", "&category_filter%5B16%5D=16",
-            "&category_filter%5B17%5D=17", "&category_filter%5B18%5D=18",
-            "&category_filter%5B19%5D=19", "&category_filter%5B20%5D=20",
-            "&category_filter%5B21%5D=21", "&category_filter%5B22%5D=22",
-            "&category_filter%5B23%5D=23", "&category_filter%5B24%5D=24",
-            "&category_filter%5B25%5D=25", "&category_filter%5B26%5D=26",
-            "&category_filter%5B27%5D=27", "&category_filter%5B28%5D=28",
-            "&category_filter%5B29%5D=29", "&category_filter%5B30%5D=30",
-            "&category_filter%5B31%5D=31", "&category_filter%5B32%5D=32",
-            "&category_filter%5B33%5D=33", "&category_filter%5B34%5D=34",
-            "&category_filter%5B35%5D=35", "&category_filter%5B36%5D=36",
-            "&category_filter%5B37%5D=37", "&category_filter%5B38%5D=38",
-            "&category_filter%5B39%5D=39", "&category_filter%5B41%5D=41",
-            "&category_filter%5B40%5D=40", "&category_filter%5B47%5D=47",
-            "&category_filter%5B48%5D=48", "&category_filter%5B42%5D=42",
-            "&category_filter%5B43%5D=43", "&category_filter%5B44%5D=44",
-            "&category_filter%5B45%5D=45"
+    private static final String[] valGenre = {
+            "&category_filter%5B1%5D=1",
+            "&category_filter%5B2%5D=2",
+            "&category_filter%5B3%5D=3",
+            "&category_filter%5B4%5D=4",
+            "&category_filter%5B5%5D=5",
+            "&category_filter%5B6%5D=6",
+            "&category_filter%5B7%5D=7",
+            "&category_filter%5B8%5D=8",
+            "&category_filter%5B9%5D=9",
+            "&category_filter%5B10%5D=10",
+            "&category_filter%5B11%5D=11",
+            "&category_filter%5B12%5D=12",
+            "&category_filter%5B13%5D=13",
+            "&category_filter%5B14%5D=14",
+            "&category_filter%5B46%5D=46",
+            "&category_filter%5B15%5D=15",
+            "&category_filter%5B16%5D=16",
+            "&category_filter%5B17%5D=17",
+            "&category_filter%5B18%5D=18",
+            "&category_filter%5B19%5D=19",
+            "&category_filter%5B20%5D=20",
+            "&category_filter%5B21%5D=21",
+            "&category_filter%5B22%5D=22",
+            "&category_filter%5B23%5D=23",
+            "&category_filter%5B24%5D=24",
+            "&category_filter%5B25%5D=25",
+            "&category_filter%5B26%5D=26",
+            "&category_filter%5B27%5D=27",
+            "&category_filter%5B28%5D=28",
+            "&category_filter%5B29%5D=29",
+            "&category_filter%5B30%5D=30",
+            "&category_filter%5B31%5D=31",
+            "&category_filter%5B32%5D=32",
+            "&category_filter%5B33%5D=33",
+            "&category_filter%5B34%5D=34",
+            "&category_filter%5B35%5D=35",
+            "&category_filter%5B36%5D=36",
+            "&category_filter%5B37%5D=37",
+            "&category_filter%5B38%5D=38",
+            "&category_filter%5B39%5D=39",
+            "&category_filter%5B41%5D=41",
+            "&category_filter%5B40%5D=40",
+            "&category_filter%5B47%5D=47",
+            "&category_filter%5B48%5D=48",
+            "&category_filter%5B42%5D=42",
+            "&category_filter%5B43%5D=43",
+            "&category_filter%5B44%5D=44",
+            "&category_filter%5B45%5D=45",
     };
 
-    private static final String[] type = {"Manga", "Manhwa", "Manhua"};
-
-    private static final String[] typeV = {
-            "&type_filter%5B1%5D=1", "&type_filter%5B2%5D=2", "&type_filter%5B3%5D=3",
+    private static final int[] fltType = {
+            R.string.flt_tag_manga,
+            R.string.flt_tag_manhwa,
+            R.string.flt_tag_manhua,
+    };
+    private static final String[] valType = {
+            "&type_filter%5B1%5D=1",
+            "&type_filter%5B2%5D=2",
+            "&type_filter%5B3%5D=3",
     };
 
-    private static final String[] state = {"Activo", "Finalizado", "Inconcluso"};
-
-    private static final String[] stateV = {
-            "&status_filter%5B1%5D=1", "&status_filter%5B2%5D=2", "&status_filter%5B3%5D=3",
+    private static final int[] fltStatus = {
+            R.string.flt_status_ongoing,
+            R.string.flt_status_completed,
+            R.string.flt_status_suspended,
+    };
+    private static final String[] valStatus = {
+            "&status_filter%5B1%5D=1",
+            "&status_filter%5B2%5D=2",
+            "&status_filter%5B3%5D=3",
     };
 
-    public Kumanga(Context context) {
+    Kumanga(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_es);
-        this.setIcon(R.drawable.kumanga);
-        this.setServerName("Kumanga");
-        setServerID(ServerBase.KUMANGA);
+        setFlag(R.drawable.flag_es);
+        setIcon(R.drawable.kumanga);
+        setServerName("Kumanga");
+        setServerID(KUMANGA);
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
     }
 
     @Override
@@ -100,13 +177,13 @@ public class Kumanga extends ServerBase {
         sb.append("&perPage=30&retrieveCategories=true&retrieveAuthors=true");
 
         for (int i = 0; i < filters[0].length; i++) {
-            sb.append(genreV[filters[0][i]]);
+            sb.append(valGenre[filters[0][i]]);
         }
         for (int i = 0; i < filters[1].length; i++) {
-            sb.append(typeV[filters[1][i]]);
+            sb.append(valType[filters[1][i]]);
         }
         for (int i = 0; i < filters[2].length; i++) {
-            sb.append(stateV[filters[2][i]]);
+            sb.append(valStatus[filters[2][i]]);
         }
 
         nav.addHeader("Accept-Language", "es-AR,es;q=0.8,en-US;q=0.5,en;q=0.3");
@@ -115,24 +192,19 @@ public class Kumanga extends ServerBase {
         nav.addHeader("X-Requested-With", "XMLHttpRequest");
         RequestBody body = RequestBody.create(MediaType.parse("application/x-www-form-urlencoded; charset=UTF-8"),
                 sb.toString());
-        String data = nav.post("http://www.kumanga.com/backend/ajax/searchengine.php",
-                body);
+        String data = nav.post(HOST + "/backend/ajax/searchengine.php", body);
         return getMangasFromJson(new JSONObject(data));
     }
 
-    private ArrayList<Manga> getMangasFromJson(JSONObject json) {
+    private ArrayList<Manga> getMangasFromJson(JSONObject json) throws Exception {
         ArrayList<Manga> mangas = new ArrayList<>();
-        try {
-            JSONArray jsonArray = json.getJSONArray("contents");
-            for (int i = 0, j = jsonArray.length(); i < j; i++) {
-                JSONObject object = (JSONObject) jsonArray.get(i);
-                Manga m = new Manga(KUMANGA, object.getString("name"),
-                        "http://www.kumanga.com/manga/" + object.getInt("id") + "/", false);
-                m.setImages("http://www.kumanga.com/kumathumb.php?src=" + object.getInt("id"));
-                mangas.add(m);
-            }
-        } catch (JSONException e) {
-            e.printStackTrace();
+        JSONArray jsonArray = json.getJSONArray("contents");
+        for (int i = 0, j = jsonArray.length(); i < j; i++) {
+            JSONObject object = (JSONObject) jsonArray.get(i);
+            Manga m = new Manga(KUMANGA, object.getString("name"),
+                    HOST + "/manga/" + object.getInt("id") + "/", false);
+            m.setImages(HOST + "kumathumb.php?src=" + object.getInt("id"));
+            mangas.add(m);
         }
         return mangas;
     }
@@ -140,53 +212,51 @@ public class Kumanga extends ServerBase {
     @Override
     public ArrayList<Manga> search(String term) throws Exception {
         Navigator nav = getNavigatorAndFlushParameters();
-        StringBuilder sb = new StringBuilder("contentType=manga&page=1&perPage=30&keywords=");
-        sb.append(term);
-        sb.append("&retrieveCategories=true&retrieveAuthors=true");
+        String web = "contentType=manga&page=1&perPage=30&keywords=";
+        web += URLEncoder.encode(term, "UTF-8");
+        web += "&retrieveCategories=true&retrieveAuthors=true";
 
         nav.addHeader("Accept-Language", "es-AR,es;q=0.8,en-US;q=0.5,en;q=0.3");
         nav.addHeader("Accept-Encoding", "deflate");
         nav.addHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
         nav.addHeader("X-Requested-With", "XMLHttpRequest");
         RequestBody body = RequestBody
-                .create(MediaType.parse("application/x-www-form-urlencoded; charset=UTF-8"),
-                sb.toString());
-        String data = nav.post("http://www.kumanga.com/backend/ajax/searchengine.php",
-                body);
-        return getMangasFromJson(new JSONObject(data));    }
+                .create(MediaType.parse("application/x-www-form-urlencoded; charset=UTF-8"), web);
+        String data = nav.post(HOST + "/backend/ajax/searchengine.php", body);
+        return getMangasFromJson(new JSONObject(data));
+    }
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        loadMangaInformation(manga,forceReload);
+        loadMangaInformation(manga, forceReload);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters().size() == 0 || forceReload) {
+        if (manga.getChapters().isEmpty() || forceReload) {
             String data = getNavigatorAndFlushParameters().get(manga.getPath());
-            //Autor
-            manga.setAuthor(Util.getInstance().fromHtml(
-                    getFirstMatchDefault("<p><b>Autor: </b>(.+?)</p>", data,
-                            context.getString(R.string.nodisponible))).toString());
-            //Generos
-            manga.setGenre(Util.getInstance().fromHtml(
-                    getFirstMatchDefault("Géneros:(.+?)</div>", data,
-                            context.getString(R.string.nodisponible))).toString());
+            // Cover
+            manga.setImages(getFirstMatchDefault("</div>\\s*<img src=\"([^\"]+)\"", data, ""));
 
-            //Sinopsis
-            manga.setSynopsis(Util.getInstance().fromHtml(
-                    getFirstMatchDefault("id=\"tab1\"><p>(.+?)</p>", data,
-                            context.getString(R.string.nodisponible))).toString());
-            //Estado
+            // Author
+            manga.setAuthor(getFirstMatchDefault("<p><b>Autor: </b>(.+?)</p>", data,
+                    context.getString(R.string.nodisponible)));
+            // Genre
+            manga.setGenre(getFirstMatchDefault("Géneros:(.+?)</div>", data,
+                    context.getString(R.string.nodisponible)).replaceAll("</a>\\s*<a", "</a>, <a"));
+
+            // Summary
+            manga.setSynopsis(getFirstMatchDefault("id=\"tab1\"><p>(.+?)</p>", data,
+                    context.getString(R.string.nodisponible)));
+            // Status
             manga.setFinished(!getFirstMatchDefault("<p><b>Estado: </b>(.+?)</p>", data, "Activo")
                     .contains("Activo"));
-            //Capítulos
-            manga.getChapters().clear();
-            Pattern pattern = Pattern.compile("<td><a href=\"(manga[^\"]+).+?>(.+?)</i>", Pattern.DOTALL);
+            // Chapters
+            Pattern pattern = Pattern.compile("<h4 class=\"title\">\\s*<a href=\"(manga[^\"]+).+?>(.+?)</i>", Pattern.DOTALL);
             Matcher matcher = pattern.matcher(data);
             while (matcher.find()) {
-                manga.addChapter(new Chapter(matcher.group(2).trim().replaceAll("<.*?>", ""),
-                        HOST + matcher.group(1)));
+                Chapter chapter = new Chapter(matcher.group(2), HOST + matcher.group(1));
+                chapter.addChapterFirst(manga);
             }
         }
     }
@@ -196,9 +266,14 @@ public class Kumanga extends ServerBase {
         return null;
     }
 
-    // http://img.kumanga.com/manga/{chapterid}/{pnumber}.jpg
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
+        if (page < 1) {
+            page = 1;
+        }
+        if (page > chapter.getPages()) {
+            page = chapter.getPages();
+        }
         return "http://img.kumanga.com/manga/" + chapter.getExtra() + "/" + page + ".jpg";
     }
 
@@ -206,18 +281,18 @@ public class Kumanga extends ServerBase {
     public void chapterInit(Chapter chapter) throws Exception {
         String data = getNavigatorAndFlushParameters().get(chapter.getPath().replace("/c/", "/leer/"));
         chapter.setPages(Integer.parseInt(getFirstMatchDefault("<select class=\"pageselector.+?>(\\d+)</option>[\\s]*</select>", data, "0")));
-        chapter.setExtra(getFirstMatch("/c/(.+)", chapter.getPath(), "Error al iniciar cápitulo(imagenes)."));
+        chapter.setExtra(getFirstMatch("/c/(.+)", chapter.getPath(), "Error: failed to get chapter path"));
     }
 
     @Override
     public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{new ServerFilter("Géneros", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Tipo", type, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Estado", state, ServerFilter.FilterType.MULTI)};
-    }
-
-    @Override
-    public boolean hasList() {
-        return false;
+        return new ServerFilter[]{
+                new ServerFilter(
+                        context.getString(R.string.flt_genre),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(context.getString(R.string.flt_type),
+                        buildTranslatedStringArray(fltType), ServerFilter.FilterType.MULTI),
+                new ServerFilter(context.getString(R.string.flt_status),
+                        buildTranslatedStringArray(fltStatus), ServerFilter.FilterType.MULTI)};
     }
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/LeoManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/LeoManga.java
@@ -1,6 +1,7 @@
 package ar.rulosoft.mimanganu.servers;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -17,57 +18,142 @@ import ar.rulosoft.mimanganu.componentes.ServerFilter;
  */
 class LeoManga extends ServerBase {
 
-    public static String HOST = "leomanga.com";
+    private static final String HOST = "http://leomanga.com";
 
-    private static String[] demografia = {
-            "Todo", "Shonen", "Shojo", "Josei", "Seinen", "Kodomo", "Yuri"
+    private static final int[] fltDemographic = {
+            R.string.flt_tag_all, //Todos
+            R.string.flt_tag_shounen, //Shonen
+            R.string.flt_tag_shoujo, //Shojo
+            R.string.flt_tag_josei, //Josei
+            R.string.flt_tag_seinen, //Seinen
+            R.string.flt_tag_kodomo, //Kodomo
+            R.string.flt_tag_yuri, //Yuri
+    };
+    private static final String[] valDemographic = {
+            "",
+            "&demografia=shonen",
+            "&demografia=shojo",
+            "&demografia=josei",
+            "&demografia=seinen",
+            "&demografia=kodomo",
+            "&demografia=yuri"
     };
 
-    private static String[] estado = {
-            "Todo", "Finalizado", "En curso"
+    private static final int[] fltStatus = {
+            R.string.flt_status_all, //Todos
+            R.string.flt_status_completed, //Finalizado
+            R.string.flt_status_ongoing //En curso
+    };
+    private static final String[] valStatus = {
+            "",
+            "&estado=finalizado",
+            "&estado=en-curso"
     };
 
-    private static String[] estadoV = {
-            "", "&estado=finalizado", "&estado=en-curso"
+    private static final int[] fltGenre = {
+            R.string.flt_tag_action, //Acción
+            R.string.flt_tag_martial_arts, //Artes Marciales
+            R.string.flt_tag_adventure, //Aventura
+            R.string.flt_tag_sci_fi, //Ciencia Ficción
+            R.string.flt_tag_comedy, //Comedia
+            R.string.flt_tag_sports, //Deporte
+            R.string.flt_tag_doujinshi, //Doujinshi
+            R.string.flt_tag_drama, //Drama
+            R.string.flt_tag_ecchi, //Ecchi
+            R.string.flt_tag_school_life, //Escolar
+            R.string.flt_tag_fantasy, //Fantasía
+            R.string.flt_tag_gender_bender, //Gender Bender
+            R.string.flt_tag_gore, //Gore
+            R.string.flt_tag_harem, //Harem
+            R.string.flt_tag_historical, //Histórico
+            R.string.flt_tag_horror, //Horror
+            R.string.flt_tag_lolicon, //Lolicon
+            R.string.flt_tag_magic, //Magia
+            R.string.flt_tag_mecha, //Mecha
+            R.string.flt_tag_mystery, //Misterio
+            R.string.flt_tag_music, //Musical
+            R.string.flt_tag_one_shot, //One-Shot
+            R.string.flt_tag_parody, //Parodia
+            R.string.flt_tag_police, //Policíaca
+            R.string.flt_tag_psychological, //Psicológica
+            R.string.flt_tag_romance, //Romance
+            R.string.flt_tag_shoujo_ai, //Shojo Ai
+            R.string.flt_tag_slice_of_life, //Slice of Life
+            R.string.flt_tag_smut, //Smut
+            R.string.flt_tag_supernatural, //Sobrenatural
+            R.string.flt_tag_super_powers, //Superpoderes
+            R.string.flt_tag_tragedy, //Tragedia
     };
-
-    private static String[] demografiaV = {
-            "", "&demografia=shonen", "&demografia=shojo", "&demografia=josei",
-            "&demografia=seinen", "&demografia=kodomo", "&demografia=yuri"
+    private static final String[] valGenre = {
+            "accion",
+            "artes-marciales",
+            "aventura",
+            "ciencia-ficcion",
+            "comedia",
+            "deporte",
+            "doujinshi",
+            "drama",
+            "ecchi",
+            "escolar",
+            "fantasia",
+            "gender-bender",
+            "gore",
+            "harem",
+            "historico",
+            "horror",
+            "lolicon",
+            "magia",
+            "mecha",
+            "misterio",
+            "musical",
+            "one-shot",
+            "parodia",
+            "policiaca",
+            "psicologica",
+            "romance",
+            "shojo-ai",
+            "slice-of-life",
+            "smut",
+            "sobrenatural",
+            "superpoderes",
+            "tragedia",
     };
-
-    private static String[] genres = {
-            "Acción", "Artes Marciales", "Aventura", "Ciencia Ficción", "Comedia",
-            "Deporte", "Doujinshi", "Drama", "Ecchi", "Escolar", "Fantasía", "Gender Bender", "Gore", "Harem", "Histórico", "Horror",
-            "Lolicon", "Magia", "Mecha", "Misterio", "Musical", "One-Shot", "Parodia", "Policíaca", "Psicológica", "Romance", "Shojo Ai",
-            "Slice of Life", "Smut", "Sobrenatural", "Superpoderes", "Tragedia"
+    private static final int[] fltOrder = {
+            R.string.flt_order_views, //Lecturas
+            R.string.flt_order_alpha, //Alphabetico
+            R.string.flt_order_rating, //Valoración
+            R.string.flt_order_last_update, //Fecha
     };
-    private static String[] categoriasV = {
-            "accion", "artes-marciales", "aventura", "ciencia-ficcion", "comedia", "deporte",
-            "doujinshi", "drama", "ecchi", "escolar", "fantasia", "gender-bender", "gore", "harem",
-            "historico", "horror", "lolicon", "magia", "mecha", "misterio", "musical", "one-shot",
-            "parodia", "policiaca", "psicologica", "romance", "shojo-ai", "slice-of-life", "smut",
-            "sobrenatural", "Superpoderes", "tragedia"
+    private static final String[] valOrder = {
+            "",
+            "&orden=alfabetico",
+            "&orden=valoracion",
+            "&orden=fecha",
     };
-    private static String[] orden = {
-            "Lecturas", "Alfabetico", "Valoración", "Fecha"
+    private static final int[] fltType = {
+            R.string.flt_tag_all,
+            R.string.flt_tag_manga,
+            R.string.flt_tag_manhwa,
+            R.string.flt_tag_manhua,
     };
-    private static String[] ordenM = {
-            "", "orden=alfabetico", "orden=valoracion", "orden=fecha"
-    };
-    private static String[] estilo = {
-            "Todos", "Manga", "Manhwa", "Manhua"
-    };
-    private static String[] estiloV = {
-            "Todos", "Manga", "Manhwa", "Manhua"
+    private static final String[] valType = {
+            "",
+            "&estilo=manga",
+            "&estilo=manhwa",
+            "&estilo=manhua",
     };
 
     LeoManga(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_es);
-        this.setIcon(R.drawable.leomanga);
-        this.setServerName("LeoManga");
-        setServerID(ServerBase.LEOMANGA);
+        setFlag(R.drawable.flag_es);
+        setIcon(R.drawable.leomanga);
+        setServerName("LeoManga");
+        setServerID(LEOMANGA);
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
     }
 
     @Override
@@ -77,13 +163,13 @@ class LeoManga extends ServerBase {
 
     @Override
     public ArrayList<Manga> search(String term) throws Exception {
-        String web = "http://" + HOST + "/buscar?s=" + URLEncoder.encode(term, "UTF-8");
+        String web = HOST + "/buscar?s=" + URLEncoder.encode(term, "UTF-8");
         String data = getNavigatorAndFlushParameters().get(web);
         Pattern pattern = Pattern.compile("<td onclick='window.location=\"(.+?)\"'>.+?<img src=\"(.+?)\"[^>]alt=\"(.+?)\"", Pattern.DOTALL);
         Matcher m = pattern.matcher(data);
         ArrayList<Manga> mangas = new ArrayList<>();
         while (m.find()) {
-            mangas.add(new Manga(LEOMANGA, m.group(3), "http://" + HOST + m.group(1), false));
+            mangas.add(new Manga(getServerID(), m.group(3), HOST + m.group(1), false));
         }
         return mangas;
     }
@@ -95,27 +181,36 @@ class LeoManga extends ServerBase {
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters().size() == 0 || forceReload) {
-
+        if (manga.getChapters().isEmpty() || forceReload) {
             String data = getNavigatorAndFlushParameters().get(manga.getPath());
-            manga.setSynopsis(getFirstMatchDefault("<p class=\"text-justify\">(.+?)</p>", data, defaultSynopsis));
+
+            // Summary
+            manga.setSynopsis(getFirstMatchDefault("<p class=\"text-justify\">(.+?)</p>", data, context.getString(R.string.nodisponible)));
+
+            // Cover
             String image = getFirstMatchDefault("<img data-original=\"(.+?)\"", data, "");
             if (image.length() > 4) {
-                manga.setImages("http://" + HOST + image);
+                manga.setImages(HOST + image);
             } else {
                 manga.setImages("");
             }
-            manga.setAuthor(getFirstMatch("<a href=\"/autor.+?\">(.+?)<", data, "n/a"));
-            manga.setGenre(getFirstMatch("Géneros:.+?</div>(.+?)</div>", data, "").replaceAll("<.*?>", "").replaceAll(",[\\s]*", ",").trim());
-            manga.setFinished(getFirstMatchDefault("curs-state\">(.+?)<", data, "").contains("Finalizado"));
 
-            ArrayList<Chapter> chapters = new ArrayList<>();
+            // Author
+            manga.setAuthor(getFirstMatchDefault("<a href=\"/autor.+?\">(.+?)<", data, context.getString(R.string.nodisponible)));
+
+            // Genre
+            manga.setGenre(getFirstMatchDefault("Géneros:.+?</div>(.+?)</div>", data, context.getString(R.string.nodisponible)));
+
+            // Status
+            manga.setFinished(getFirstMatchDefault("-state\">(.+?)</div>", data, "").contains("Finalizado"));
+
+            // Chapters
             Pattern pattern = Pattern.compile("<li>[\\s]*<a href=\"(/manga/.+?)\">(.+?)</a>", Pattern.DOTALL);
             Matcher matcher = pattern.matcher(data);
             while (matcher.find()) {
-                chapters.add(0,new Chapter(matcher.group(2).replaceAll("<.+?>", "").trim(), "http://" + HOST + matcher.group(1)));
+                Chapter chapter = new Chapter(matcher.group(2), HOST + matcher.group(1));
+                chapter.addChapterFirst(manga);
             }
-            manga.setChapters(chapters);
         }
     }
 
@@ -126,71 +221,72 @@ class LeoManga extends ServerBase {
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
-        return chapter.getExtra().split("\\|")[page];
+        String extra = chapter.getExtra();
+        if (extra != null) {
+            return HOST + extra.split("\\|")[page];
+        }
+        throw new Exception("Error: no image link for this page found");
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
         String data = getNavigatorAndFlushParameters().get(chapter.getPath());
-        String web = "http://" + HOST + getFirstMatch("href=\"([^\"]+)\">Online", data, "Error obteniendo paginas 1");
+        String web = HOST + getFirstMatch("href=\"([^\"]+)\">Online", data, "Error: failed to get first indirection");
         data = getNavigatorAndFlushParameters().get(web);
-        String sub = "http://" + HOST + getFirstMatch("id=\"read-chapter\" data-name=\"(.+?)\"", data, "Error obteniendo paginas 3");
-        String[] pos = getFirstMatch("pos=\"(.+?)\"", data, "Error obteniendo paginas 4").split(";");
-        chapter.setPages(pos.length);
-        String images = "";
-        for (String i : pos) {
-            images = images + "|" + sub + i;
-        }
-        chapter.setExtra(images);
+        ArrayList<String> pos = getAllMatch("class=\"cap-images\" src=\"(.+?)\"", data);
+        chapter.setPages(pos.size());
+        chapter.setExtra(TextUtils.join("|", pos));
     }
 
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
-        String web = "http://" + HOST + "/directorio-manga?pagina=" + pageNumber;
-        //demografia
-        web = web + demografiaV[filters[0][0]];
-        //genero
-        String gen = "&genero=";
-        for (int i = 0; i < filters[1].length; i++) {
-            gen = gen + categoriasV[filters[1][i]] + "|";
-        }
-        if (gen.length() > 8) {
-            gen = gen.substring(0, gen.length() - 1);
-            web = web + gen;
-        }
+        String web;
 
-        //estado
-        web = web + estadoV[filters[2][0]];
-        //orden
-        web = web + ordenM[filters[3][0]];
+        web = HOST + "/directorio-manga?pagina=" + pageNumber;
+        web += valType[filters[0][0]];
+        web += valDemographic[filters[1][0]];
+        if (filters[2].length > 0) {
+            String gen = "&genero=";
+            for (int i = 0; i < filters[2].length; i++) {
+                gen += valGenre[filters[2][i]] + "|";
+            }
+            web += gen.substring(0, gen.length() - 1);
+        }
+        web += valStatus[filters[3][0]];
+        web += valOrder[filters[4][0]];
+
         String data = getNavigatorAndFlushParameters().get(web);
-        return getMangasFromSource(data);
-    }
-
-    private ArrayList<Manga> getMangasFromSource(String data) {
         ArrayList<Manga> mangas = new ArrayList<>();
         Pattern p = Pattern.compile("<a href=\"(/manga/.+?)\".+?src=\"(.+?)\" alt=\"(.+?)\"", Pattern.DOTALL);
         Matcher m = p.matcher(data);
         while (m.find()) {
-            Manga manga = new Manga(LEOMANGA, m.group(3), "http://" + HOST + m.group(1), false);
-            manga.setImages("http://" + HOST + m.group(2).replace("thumb-", ""));
+            Manga manga = new Manga(getServerID(), m.group(3), HOST + m.group(1), false);
+            manga.setImages(HOST + m.group(2).replace("thumb-", ""));
             mangas.add(manga);
         }
+        hasMore = !mangas.isEmpty();
         return mangas;
     }
 
     @Override
     public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{new ServerFilter("Demografia", demografia, ServerFilter.FilterType.SINGLE),
-                new ServerFilter("Genero", genres, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Estado", estado, ServerFilter.FilterType.SINGLE),
-                new ServerFilter("Orden", orden, ServerFilter.FilterType.SINGLE)
+        return new ServerFilter[]{
+                new ServerFilter(
+                        context.getString(R.string.flt_type),
+                        buildTranslatedStringArray(fltType), ServerFilter.FilterType.SINGLE),
+                new ServerFilter(
+                        context.getString(R.string.flt_demographic),
+                        buildTranslatedStringArray(fltDemographic), ServerFilter.FilterType.SINGLE),
+                new ServerFilter(
+                        context.getString(R.string.flt_genre),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_status),
+                        buildTranslatedStringArray(fltStatus), ServerFilter.FilterType.SINGLE),
+                new ServerFilter(
+                        context.getString(R.string.flt_order),
+                        buildTranslatedStringArray(fltOrder), ServerFilter.FilterType.SINGLE)
         };
-    }
-
-    @Override
-    public boolean hasList() {
-        return false;
     }
 
     @Override

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaEden.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaEden.java
@@ -11,65 +11,135 @@ import ar.rulosoft.mimanganu.R;
 import ar.rulosoft.mimanganu.componentes.Chapter;
 import ar.rulosoft.mimanganu.componentes.Manga;
 import ar.rulosoft.mimanganu.componentes.ServerFilter;
-import ar.rulosoft.mimanganu.utils.Util;
 
 /**
  * Created by jtx on 07.05.2016.
  */
 class MangaEden extends ServerBase {
 
-    public static String HOST = "http://www.mangaeden.com/";
+    private static final String HOST = "http://www.mangaeden.com/";
 
-    private static String[] genre = new String[]{
-            "Action", "Adult",
-            "Adventure", "Comedy", "Doujinshi", "Drama", "Ecchi", "Fantasy",
-            "Gender Bender", "Harem", "Historical", "Horror", "Josei", "Martial Arts",
-            "Mature", "Mecha", "Mystery", "One Shot", "Psychological", "Romance",
-            "School Life", "Sci-fi", "Seinen", "Shoujo", "Shounen", "Slice of Life",
-            "Smut", "Sports", "Supernatural", "Tragedy", "Webtoons", "Yaoi",
-            "Yuri"
+    private static final int[] flgGenre = {
+            R.string.flt_tag_action,
+            R.string.flt_tag_adult,
+            R.string.flt_tag_adventure,
+            R.string.flt_tag_comedy,
+            R.string.flt_tag_doujinshi,
+            R.string.flt_tag_drama,
+            R.string.flt_tag_ecchi,
+            R.string.flt_tag_fantasy,
+            R.string.flt_tag_gender_bender,
+            R.string.flt_tag_harem,
+            R.string.flt_tag_historical,
+            R.string.flt_tag_horror,
+            R.string.flt_tag_josei,
+            R.string.flt_tag_martial_arts,
+            R.string.flt_tag_mature,
+            R.string.flt_tag_mecha,
+            R.string.flt_tag_mystery,
+            R.string.flt_tag_one_shot,
+            R.string.flt_tag_psychological,
+            R.string.flt_tag_romance,
+            R.string.flt_tag_school_life,
+            R.string.flt_tag_sci_fi,
+            R.string.flt_tag_seinen,
+            R.string.flt_tag_shoujo,
+            R.string.flt_tag_shounen,
+            R.string.flt_tag_slice_of_life,
+            R.string.flt_tag_smut,
+            R.string.flt_tag_sports,
+            R.string.flt_tag_supernatural,
+            R.string.flt_tag_tragedy,
+            R.string.flt_tag_webtoon,
+            R.string.flt_tag_yaoi,
+            R.string.flt_tag_yuri
     };
-
-    private static String[] genreV = new String[]{
-            "4e70e91bc092255ef70016f8", "4e70e92fc092255ef7001b94",
-            "4e70e918c092255ef700168e", "4e70e918c092255ef7001675", "4e70e928c092255ef7001a0a", "4e70e918c092255ef7001693", "4e70e91ec092255ef700175e", "4e70e918c092255ef7001676",
-            "4e70e921c092255ef700184b", "4e70e91fc092255ef7001783", "4e70e91ac092255ef70016d8", "4e70e919c092255ef70016a8", "4e70e920c092255ef70017de", "4e70e923c092255ef70018d0",
-            "4e70e91bc092255ef7001705", "4e70e922c092255ef7001877", "4e70e918c092255ef7001681", "4e70e91dc092255ef7001747", "4e70e919c092255ef70016a9", "4e70e918c092255ef7001677",
-            "4e70e918c092255ef7001688", "4e70e91bc092255ef7001706", "4e70e918c092255ef700168b", "4e70e918c092255ef7001667", "4e70e918c092255ef700166f", "4e70e918c092255ef700167e",
-            "4e70e922c092255ef700185a", "4e70e91dc092255ef700172e", "4e70e918c092255ef700166a", "4e70e918c092255ef7001672", "4e70ea70c092255ef7006d9c", "4e70e91ac092255ef70016e5",
+    private static final String[] valGenre = {
+            "4e70e91bc092255ef70016f8",
+            "4e70e92fc092255ef7001b94",
+            "4e70e918c092255ef700168e",
+            "4e70e918c092255ef7001675",
+            "4e70e928c092255ef7001a0a",
+            "4e70e918c092255ef7001693",
+            "4e70e91ec092255ef700175e",
+            "4e70e918c092255ef7001676",
+            "4e70e921c092255ef700184b",
+            "4e70e91fc092255ef7001783",
+            "4e70e91ac092255ef70016d8",
+            "4e70e919c092255ef70016a8",
+            "4e70e920c092255ef70017de",
+            "4e70e923c092255ef70018d0",
+            "4e70e91bc092255ef7001705",
+            "4e70e922c092255ef7001877",
+            "4e70e918c092255ef7001681",
+            "4e70e91dc092255ef7001747",
+            "4e70e919c092255ef70016a9",
+            "4e70e918c092255ef7001677",
+            "4e70e918c092255ef7001688",
+            "4e70e91bc092255ef7001706",
+            "4e70e918c092255ef700168b",
+            "4e70e918c092255ef7001667",
+            "4e70e918c092255ef700166f",
+            "4e70e918c092255ef700167e",
+            "4e70e922c092255ef700185a",
+            "4e70e91dc092255ef700172e",
+            "4e70e918c092255ef700166a",
+            "4e70e918c092255ef7001672",
+            "4e70ea70c092255ef7006d9c",
+            "4e70e91ac092255ef70016e5",
             "4e70e92ac092255ef7001a57"
     };
 
-    private static String[] type = new String[]{
-            "Japanese Manga", "Korean Manhwa", "Chinese Manhua", "Comic", "Doujinshi"
+    private static final int[] fltType = {
+            R.string.flt_tag_manga,
+            R.string.flt_tag_manhwa,
+            R.string.flt_tag_manhua,
+            R.string.flt_tag_comic,
+            R.string.flt_tag_doujinshi
+    };
+    private static final String[] valType = {
+            "&type=0",
+            "&type=1",
+            "&type=2",
+            "&type=3",
+            "&type=4"
     };
 
-    private static String[] typeV = new String[]{
-            "&type=0", "&type=1", "&type=2", "&type=3", "&type=4"
+    private static final int[] fltStatus = {
+            R.string.flt_status_ongoing,
+            R.string.flt_status_completed,
+            R.string.flt_status_suspended
+    };
+    private static final String[] valStatus = {
+            "&status=1",
+            "&status=2",
+            "&status=0"
     };
 
-    private static String[] status = new String[]{
-            "Ongoing", "Completed", "Suspended"
+    private static final int[] fltOrder = {
+            R.string.flt_order_views,
+            R.string.flt_order_last_update,
+            R.string.flt_order_title,
+            R.string.flt_order_chapters
     };
-
-    private static String[] statusV = new String[]{
-            "&status=1", "&status=2", "&status=0"
-    };
-
-    private static String[] order = new String[]{
-            "Front page", "Views", "Latest Chapter", "Manga Title", "Chapters"
-    };
-
-    private static String[] orderV = new String[]{
-            "", "&order=1", "&order=3", "&order=-0", "&order=2"
+    private static final String[] orderV = {
+            "", // same as "&order=1",
+            "&order=3",
+            "&order=-0",
+            "&order=2"
     };
 
     MangaEden(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_en);
-        this.setIcon(R.drawable.mangaeden);
-        this.setServerName("MangaEden");
-        setServerID(ServerBase.MANGAEDEN);
+        setFlag(R.drawable.flag_en);
+        setIcon(R.drawable.mangaeden);
+        setServerName("MangaEden");
+        setServerID(MANGAEDEN);
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
     }
 
     @Override
@@ -85,38 +155,36 @@ class MangaEden extends ServerBase {
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters() == null || manga.getChapters().size() == 0 || forceReload)
-            loadMangaInformation(manga, forceReload);
+        loadMangaInformation(manga, forceReload);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        String source = getNavigatorAndFlushParameters().get(manga.getPath());
-        // Front
-        String image = getFirstMatchDefault("<div class=\"mangaImage2\"><img src=\"(.+?)\"", source, "");
-        if(image.length() > 2)
-            image = "http:" + image;
-        manga.setImages(image);
-        // Summary
-        String summary = getFirstMatchDefault("mangaDescription\">(.+?)</h",
-                source, defaultSynopsis).replaceAll("<.+?>", "");
-        manga.setSynopsis(Util.getInstance().fromHtml(summary).toString());
-        // Status
-        manga.setFinished(getFirstMatchDefault("Status</h(.+?)<h", source, "").contains("Completed"));
-        // Author
-        manga.setAuthor(Util.getInstance().fromHtml(getFirstMatchDefault("Author</h4>(.+?)<h4>", source, "")).toString().trim().replaceAll("\n", ""));
-        // Genres
-        manga.setGenre((Util.getInstance().fromHtml(getFirstMatchDefault("Genres</h4>(.+?)<h4>", source, "").replace("a><a", "a>, <a")).toString().trim()));
-        // Chapters
-        Pattern pattern = Pattern.compile("<tr.+?href=\"(/en/en-manga/.+?)\".+?>(.+?)</a", Pattern.DOTALL);
-        Matcher matcher = pattern.matcher(source);
-        ArrayList<Chapter> chapters = new ArrayList<>();
-        while (matcher.find()) {
-            /*Log.d("ME", "1: " + matcher.group(1));
-            Log.d("ME", "2: " + matcher.group(2));*/
-            chapters.add(0, new Chapter(Util.getInstance().fromHtml(matcher.group(2).replaceAll("Chapter", " Ch ")).toString(), HOST + matcher.group(1)));
+        if (manga.getChapters().isEmpty() || forceReload) {
+            String source = getNavigatorAndFlushParameters().get(manga.getPath());
+            // Front
+            String image = getFirstMatchDefault("<div class=\"mangaImage2\"><img src=\"(.+?)\"", source, "");
+            if (image.length() > 2) {
+                image = "http:" + image;
+            }
+            manga.setImages(image);
+            // Summary
+            manga.setSynopsis(
+                    getFirstMatchDefault("mangaDescription\">(.+?)</h", source, context.getString(R.string.nodisponible)));
+            // Status
+            manga.setFinished(getFirstMatchDefault("Status</h(.+?)<h", source, "").contains("Completed"));
+            // Author
+            manga.setAuthor(getFirstMatchDefault("Author</h4>(.+?)<h4>", source, context.getString(R.string.nodisponible)));
+            // Genres
+            manga.setGenre(getFirstMatchDefault("Genres</h4>(.+?)<h4>", source, context.getString(R.string.nodisponible)));
+            // Chapters
+            Pattern pattern = Pattern.compile("<tr.+?href=\"(/en/en-manga/.+?)\".+?>(.+?)</a", Pattern.DOTALL);
+            Matcher matcher = pattern.matcher(source);
+            while (matcher.find()) {
+                Chapter chapter = new Chapter(matcher.group(2).replaceAll("Chapter", " Ch "), HOST + matcher.group(1));
+                chapter.addChapterFirst(manga);
+            }
         }
-        manga.setChapters(chapters);
     }
 
     @Override
@@ -140,7 +208,6 @@ class MangaEden extends ServerBase {
         String images = "";
         while (matcher.find()) {
             pages++;
-            //Log.d("ME", "1: " + "http:" + matcher.group(1));
             images = images + "|" + "http:" + matcher.group(1);
         }
         chapter.setExtra(images);
@@ -151,12 +218,13 @@ class MangaEden extends ServerBase {
     public void chapterInit(Chapter chapter) throws Exception {
         if (chapter.getExtra() == null || chapter.getExtra().length() < 2) {
             chapter.setPages(setExtra(chapter));
-        } else
+        } else {
             chapter.setPages(0);
+        }
     }
 
     private ArrayList<Manga> getMangasFromSource(String source) {
-        Pattern pattern = Pattern.compile("<tr><td><a href=\"/en/en-manga/(.+?)\" class=\"(.+?)\">(.+?)</a>", Pattern.DOTALL);
+        Pattern pattern = Pattern.compile("<tr>[^<]*<td>[^<]*<a href=\"/en/en-manga/(.+?)\" class=\"(.+?)\">(.+?)</a>", Pattern.DOTALL);
         Matcher matcher = pattern.matcher(source);
         ArrayList<Manga> mangas = new ArrayList<>();
         while (matcher.find()) {
@@ -170,59 +238,60 @@ class MangaEden extends ServerBase {
         String newSource = "";
         try {
             newSource = getFirstMatchDefault("<ul id=\"news\"(.+?)</ul>", source, "");
-            //Log.d("ME","nS: "+newSource);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        Pattern pattern1 = Pattern.compile("<img src=\"(//cdn\\.mangaeden\\.com/mangasimg/.+?)\".+?<div class=\"hottestInfo\">[\\s]*<a href=\"(/en/en-manga/[^\"<>]+?)\" class=.+?\">(.+?)</a>", Pattern.DOTALL);
-        Matcher matcher1;
-        if (newSource.isEmpty())
-            matcher1 = pattern1.matcher(source);
-        else
-            matcher1 = pattern1.matcher(newSource);
+        Pattern pattern = Pattern.compile("<img src=\"(//cdn\\.mangaeden\\.com/mangasimg/.+?)\".+?<div class=\"hottestInfo\">[\\s]*<a href=\"(/en/en-manga/[^\"<>]+?)\" class=.+?\">(.+?)</a>", Pattern.DOTALL);
+        Matcher matcher;
+        if (newSource.isEmpty()) {
+            matcher = pattern.matcher(source);
+        }
+        else {
+            matcher = pattern.matcher(newSource);
+        }
         ArrayList<Manga> mangas = new ArrayList<>();
         int i = 0;
-        while (matcher1.find()) {
+        while (matcher.find()) {
             i++;
-            /*Log.d("ME", "(1): " + "http:" + matcher1.group(1));
-            Log.d("ME", "(2): " + matcher1.group(2));
-            Log.d("ME", "(3): " + matcher1.group(3));*/
-            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(matcher1.group(3)).toString(), HOST + matcher1.group(2), false);
-            manga.setImages("http:" + matcher1.group(1));
+            Manga manga = new Manga(getServerID(), matcher.group(3), HOST + matcher.group(2), false);
+            manga.setImages("http:" + matcher.group(1));
             mangas.add(manga);
-            //Log.d("ME", "i: " + i);
-            if (newSource.isEmpty())
-                if (i == 60)
+            if (newSource.isEmpty()) {
+                if (i == 60) {
                     break;
+                }
+            }
         }
         return mangas;
     }
 
     //http://www.mangaeden.com/en/en-directory/?status=2&author=&title=&releasedType=0&released=&artist=&type=0&categoriesInc=4e70e91bc092255ef70016f8&categoriesInc=4e70e91ec092255ef700175e&page=2
 
-
+    // when filtering is active, the result will have no images. this can't be helped.
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
-        String web = HOST + "en/en-directory/?author=&title=";
+        String web = HOST + "en/en-directory/?author=&title=&artist=";
+        String nofilters = web;
         for (int i = 0; i < filters[3].length; i++) {
-            web = web + statusV[filters[3][i]];
+            web = web + valStatus[filters[3][i]];
         }
         for (int i = 0; i < filters[1].length; i++) {
-            web = web + "&categoriesInc=" + genreV[filters[1][i]];
+            web = web + "&categoriesInc=" + valGenre[filters[1][i]];
         }
         for (int i = 0; i < filters[2].length; i++) {
-            web = web + "&categoriesExcl=" + genreV[filters[2][i]];
+            web = web + "&categoriesExcl=" + valGenre[filters[2][i]];
         }
-        web = web + "&artist=";
         for (int i = 0; i < filters[0].length; i++) {
-            web = web + typeV[filters[0][i]];
+            web = web + valType[filters[0][i]];
         }
-        if (orderV[filters[4][0]].equals("")) {
-            web = "http://www.mangaeden.com/eng/";
+        if (orderV[filters[4][0]].equals("") && web.equals(nofilters)) {
+            // no filters are active - simply fetch the front page
+            web = HOST + "/eng/";
             String source = getNavigatorAndFlushParameters().get(web);
             return getMangasFromFrontpage(source);
         } else {
+            // filtering is active, get results from the list
             web = web + orderV[filters[4][0]] + "&page=" + pageNumber;
             String source = getNavigatorAndFlushParameters().get(web);
             return getMangasFromSource(source);
@@ -231,16 +300,22 @@ class MangaEden extends ServerBase {
 
     @Override
     public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{new ServerFilter("Type", type, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Included Genre(s)", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Excluded Genre(s)", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Status", status, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Order", order, ServerFilter.FilterType.SINGLE)
+        return new ServerFilter[] {
+                new ServerFilter(
+                        context.getString(R.string.flt_type),
+                        buildTranslatedStringArray(fltType), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_include_tags),
+                        buildTranslatedStringArray(flgGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_exclude_tags),
+                        buildTranslatedStringArray(flgGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_status),
+                        buildTranslatedStringArray(fltStatus), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_order),
+                        buildTranslatedStringArray(fltOrder), ServerFilter.FilterType.SINGLE)
         };
-    }
-
-    @Override
-    public boolean hasList() {
-        return false;
     }
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaEden.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaEden.java
@@ -17,9 +17,9 @@ import ar.rulosoft.mimanganu.componentes.ServerFilter;
  */
 class MangaEden extends ServerBase {
 
-    private static final String HOST = "http://www.mangaeden.com/";
+    protected static final String HOST = "http://www.mangaeden.com/";
 
-    private static final int[] flgGenre = {
+    protected int[] fltGenre = {
             R.string.flt_tag_action,
             R.string.flt_tag_adult,
             R.string.flt_tag_adventure,
@@ -54,7 +54,7 @@ class MangaEden extends ServerBase {
             R.string.flt_tag_yaoi,
             R.string.flt_tag_yuri
     };
-    private static final String[] valGenre = {
+    protected String[] valGenre = {
             "4e70e91bc092255ef70016f8",
             "4e70e92fc092255ef7001b94",
             "4e70e918c092255ef700168e",
@@ -129,12 +129,22 @@ class MangaEden extends ServerBase {
             "&order=2"
     };
 
+    private String lang_2l;
+    private String lang_3l;
+
     MangaEden(Context context) {
         super(context);
         setFlag(R.drawable.flag_en);
         setIcon(R.drawable.mangaeden);
         setServerName("MangaEden");
         setServerID(MANGAEDEN);
+        setLanguage("en", "eng");
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    protected void setLanguage(String l2l, String l3l) {
+        lang_2l = l2l;
+        lang_3l = l3l;
     }
 
     @Override
@@ -149,7 +159,7 @@ class MangaEden extends ServerBase {
 
     @Override
     public ArrayList<Manga> search(String term) throws Exception {
-        String source = getNavigatorAndFlushParameters().get("http://www.mangaeden.com/en/en-directory/?title=" + URLEncoder.encode(term, "UTF-8") + "&author=&artist=&releasedType=0&released=");
+        String source = getNavigatorAndFlushParameters().get(HOST + "/" + lang_2l + "/" + lang_2l + "-directory/?title=" + URLEncoder.encode(term, "UTF-8") + "&author=&artist=&releasedType=0&released=");
         return getMangasFromSource(source);
     }
 
@@ -224,11 +234,11 @@ class MangaEden extends ServerBase {
     }
 
     private ArrayList<Manga> getMangasFromSource(String source) {
-        Pattern pattern = Pattern.compile("<tr>[^<]*<td>[^<]*<a href=\"/en/en-manga/(.+?)\" class=\"(.+?)\">(.+?)</a>", Pattern.DOTALL);
+        Pattern pattern = Pattern.compile("<tr>[^<]*<td>[^<]*<a href=\"/" + lang_2l + "/" + lang_2l + "-manga/(.+?)\" class=\"(.+?)\">(.+?)</a>", Pattern.DOTALL);
         Matcher matcher = pattern.matcher(source);
         ArrayList<Manga> mangas = new ArrayList<>();
         while (matcher.find()) {
-            Manga manga = new Manga(getServerID(), matcher.group(3), HOST + "en/en-manga/" +  matcher.group(1), matcher.group(2).contains("close"));
+            Manga manga = new Manga(getServerID(), matcher.group(3), HOST + "/" + lang_2l + "/" + lang_2l + "-manga/" +  matcher.group(1), matcher.group(2).contains("close"));
             mangas.add(manga);
         }
         return mangas;
@@ -242,7 +252,7 @@ class MangaEden extends ServerBase {
             e.printStackTrace();
         }
 
-        Pattern pattern = Pattern.compile("<img src=\"(//cdn\\.mangaeden\\.com/mangasimg/.+?)\".+?<div class=\"hottestInfo\">[\\s]*<a href=\"(/en/en-manga/[^\"<>]+?)\" class=.+?\">(.+?)</a>", Pattern.DOTALL);
+        Pattern pattern = Pattern.compile("<img src=\"(//cdn\\.mangaeden\\.com/mangasimg/.+?)\".+?<div class=\"hottestInfo\">[\\s]*<a href=\"(/" + lang_2l + "/" + lang_2l + "-manga/[^\"<>]+?)\" class=.+?\">(.+?)</a>", Pattern.DOTALL);
         Matcher matcher;
         if (newSource.isEmpty()) {
             matcher = pattern.matcher(source);
@@ -271,7 +281,7 @@ class MangaEden extends ServerBase {
     // when filtering is active, the result will have no images. this can't be helped.
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
-        String web = HOST + "en/en-directory/?author=&title=&artist=";
+        String web = HOST + "/" + lang_2l + "/" + lang_2l + "-directory/?author=&title=&artist=";
         String nofilters = web;
         for (int i = 0; i < filters[3].length; i++) {
             web = web + valStatus[filters[3][i]];
@@ -287,7 +297,7 @@ class MangaEden extends ServerBase {
         }
         if (orderV[filters[4][0]].equals("") && web.equals(nofilters)) {
             // no filters are active - simply fetch the front page
-            web = HOST + "/eng/";
+            web = HOST + "/" + lang_3l + "/";
             String source = getNavigatorAndFlushParameters().get(web);
             return getMangasFromFrontpage(source);
         } else {
@@ -306,10 +316,10 @@ class MangaEden extends ServerBase {
                         buildTranslatedStringArray(fltType), ServerFilter.FilterType.MULTI),
                 new ServerFilter(
                         context.getString(R.string.flt_include_tags),
-                        buildTranslatedStringArray(flgGenre), ServerFilter.FilterType.MULTI),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
                 new ServerFilter(
                         context.getString(R.string.flt_exclude_tags),
-                        buildTranslatedStringArray(flgGenre), ServerFilter.FilterType.MULTI),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
                 new ServerFilter(
                         context.getString(R.string.flt_status),
                         buildTranslatedStringArray(fltStatus), ServerFilter.FilterType.MULTI),
@@ -319,3 +329,4 @@ class MangaEden extends ServerBase {
         };
     }
 }
+

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaEdenIt.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaEdenIt.java
@@ -2,238 +2,132 @@ package ar.rulosoft.mimanganu.servers;
 
 import android.content.Context;
 
-import java.net.URLEncoder;
-import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import ar.rulosoft.mimanganu.R;
 import ar.rulosoft.mimanganu.componentes.Chapter;
 import ar.rulosoft.mimanganu.componentes.Manga;
-import ar.rulosoft.mimanganu.componentes.ServerFilter;
-import ar.rulosoft.mimanganu.utils.Util;
 
 /**
  * Created by Raul on 03/12/2015.
  */
-class MangaEdenIt extends ServerBase {
+class MangaEdenIt extends MangaEden {
 
-    public static String HOST = "http://www.mangaeden.com/";
-
-    private static String[] genre = new String[]{
-            "Avventura", "Azione", "Bara", "Commedia", "Demenziale",
-            "Dounshinji","Drama","Ecchi","Fantasy","Harem","Hentai",
-            "Horror","Josei","Magico","Mecha","Misteri","Musica",
-            "Psicologico","Raccolta","Romantico","Sci-Fi","Scolastico","Seinen",
-            "Sentimentale","Shota","Shoujo","Shounen","Sovrannaturale","Splatter",
-            "Sportivo","Storico","Vita Quotidiana","Yaoi","Yuri"
+    private static final int[] fltGenre = {
+            R.string.flt_tag_adventure, //Avventura
+            R.string.flt_tag_action, //Azione
+            R.string.flt_tag_bara, //Bara
+            R.string.flt_tag_comedy, //Commedia
+            R.string.flt_tag_madness, //Demenziale (?)
+            R.string.flt_tag_doujinshi, //Dounshinji
+            R.string.flt_tag_drama, //Drama
+            R.string.flt_tag_ecchi, //Ecchi
+            R.string.flt_tag_fantasy, //Fantasy
+            R.string.flt_tag_harem, //Harem
+            R.string.flt_tag_hentai, //Hentai
+            R.string.flt_tag_horror, //Horror
+            R.string.flt_tag_josei, //Josei
+            R.string.flt_tag_magic, //Magico
+            R.string.flt_tag_mecha, //Mecha
+            R.string.flt_tag_mystery, //Misteri
+            R.string.flt_tag_music, //Musica
+            R.string.flt_tag_psychological, //Psicologico
+            R.string.flt_tag_collection, //Raccolta (?)
+            R.string.flt_tag_romance, //Romantico
+            R.string.flt_tag_sci_fi, //Sci-Fi
+            R.string.flt_tag_school_life, //Scolastico
+            R.string.flt_tag_seinen, //Seinen
+            R.string.flt_tag_relation, //Sentimentale (?)
+            R.string.flt_tag_shota, //Shota
+            R.string.flt_tag_shoujo, //Shoujo
+            R.string.flt_tag_shounen, //Shounen
+            R.string.flt_tag_supernatural, //Sovrannaturale
+            R.string.flt_tag_splatter, //Splatter
+            R.string.flt_tag_sports, //Sportivo
+            R.string.flt_tag_historical, //Storico
+            R.string.flt_tag_slice_of_life, //Vita Quotidiana
+            R.string.flt_tag_yaoi, //Yaoi
+            R.string.flt_tag_yuri //Yuri
     };
 
-    private static String[] genreV = new String[]{
-            "4e70ea8cc092255ef70073d3", "4e70ea8cc092255ef70073c3", "4e70ea90c092255ef70074b7", "4e70ea8cc092255ef70073d0", "4e70ea8fc092255ef7007475",
-            "4e70ea93c092255ef70074e4","4e70ea8cc092255ef70073f9","4e70ea8cc092255ef70073cd","4e70ea8cc092255ef70073c4","4e70ea8cc092255ef70073d1","4e70ea90c092255ef700749a",
-            "4e70ea8cc092255ef70073ce","4e70ea90c092255ef70074bd","4e70ea93c092255ef700751b","4e70ea8cc092255ef70073ef","4e70ea8dc092255ef700740a","4e70ea8fc092255ef7007456",
-            "4e70ea8ec092255ef7007439","4e70ea90c092255ef70074ae","4e70ea8cc092255ef70073c5","4e70ea8cc092255ef70073e4","4e70ea8cc092255ef70073e5","4e70ea8cc092255ef70073ea",
-            "4e70ea8dc092255ef7007432","4e70ea90c092255ef70074b8","4e70ea8dc092255ef7007421","4e70ea8cc092255ef70073c6","4e70ea8cc092255ef70073c7","4e70ea99c092255ef70075a3",
-            "4e70ea8dc092255ef7007426","4e70ea8cc092255ef70073f4","4e70ea8ec092255ef700743f","4e70ea8cc092255ef70073de","4e70ea9ac092255ef70075d1"
-    };
-
-    private static String[] type = new String[]{
-            "Japanese Manga", "Korean Manhwa", "Chinese Manhua", "Comic", "Doujinshi"
-    };
-
-    private static String[] typeV = new String[]{
-            "&type=0", "&type=1", "&type=2", "&type=3", "&type=4"
-    };
-
-    private static String[] status = new String[]{
-            "Ongoing", "Completed", "Suspended"
-    };
-
-    private static String[] statusV = new String[]{
-            "&status=1", "&status=2", "&status=0"
-    };
-
-    private static String[] order = new String[]{
-            "Front page", "Views", "Latest Chapter", "Manga Title", "Chapters"
-    };
-
-    private static String[] orderV = new String[]{
-            "", "&order=1", "&order=3", "&order=-0", "&order=2"
+    private static final String[] valGenre = {
+            "4e70ea8cc092255ef70073d3",
+            "4e70ea8cc092255ef70073c3",
+            "4e70ea90c092255ef70074b7",
+            "4e70ea8cc092255ef70073d0",
+            "4e70ea8fc092255ef7007475",
+            "4e70ea93c092255ef70074e4",
+            "4e70ea8cc092255ef70073f9",
+            "4e70ea8cc092255ef70073cd",
+            "4e70ea8cc092255ef70073c4",
+            "4e70ea8cc092255ef70073d1",
+            "4e70ea90c092255ef700749a",
+            "4e70ea8cc092255ef70073ce",
+            "4e70ea90c092255ef70074bd",
+            "4e70ea93c092255ef700751b",
+            "4e70ea8cc092255ef70073ef",
+            "4e70ea8dc092255ef700740a",
+            "4e70ea8fc092255ef7007456",
+            "4e70ea8ec092255ef7007439",
+            "4e70ea90c092255ef70074ae",
+            "4e70ea8cc092255ef70073c5",
+            "4e70ea8cc092255ef70073e4",
+            "4e70ea8cc092255ef70073e5",
+            "4e70ea8cc092255ef70073ea",
+            "4e70ea8dc092255ef7007432",
+            "4e70ea90c092255ef70074b8",
+            "4e70ea8dc092255ef7007421",
+            "4e70ea8cc092255ef70073c6",
+            "4e70ea8cc092255ef70073c7",
+            "4e70ea99c092255ef70075a3",
+            "4e70ea8dc092255ef7007426",
+            "4e70ea8cc092255ef70073f4",
+            "4e70ea8ec092255ef700743f",
+            "4e70ea8cc092255ef70073de",
+            "4e70ea9ac092255ef70075d1",
+            "4e70ea8cc092255ef70073d3"
     };
 
     MangaEdenIt(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_it);
-        this.setIcon(R.drawable.mangaeden);
-        this.setServerName("MangaEdentIt");
-        setServerID(ServerBase.MANGAEDENIT);
-    }
+        setFlag(R.drawable.flag_it);
+        setIcon(R.drawable.mangaeden);
+        setServerName("MangaEdenIt");
+        setServerID(MANGAEDENIT);
+        setLanguage("it", "it");
 
-    @Override
-    public ArrayList<Manga> getMangas() throws Exception {
-        return null;
-    }
-
-    @Override
-    public ArrayList<Manga> search(String term) throws Exception {
-        String source = getNavigatorAndFlushParameters().get("http://www.mangaeden.com/it/it-directory/?title=" + URLEncoder.encode(term, "UTF-8") + "&author=&artist=&releasedType=0&released=");
-        return getMangasFromSource(source);
-    }
-
-    @Override
-    public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters() == null || manga.getChapters().size() == 0 || forceReload)
-            loadMangaInformation(manga, forceReload);
+        // override super variables
+        super.fltGenre = fltGenre;
+        super.valGenre = valGenre;
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        String source = getNavigatorAndFlushParameters().get(manga.getPath());
-        // Front
-        String image = getFirstMatchDefault("<div class=\"mangaImage2\"><img src=\"(.+?)\"", source, "");
-        if(image.length() > 2)
-            image = "http:" + image;
-        manga.setImages(image);
-        // Summary
-        String summary = getFirstMatchDefault("mangaDescription\">(.+?)</h",
-                source, defaultSynopsis).replaceAll("<.+?>", "");
-        manga.setSynopsis(Util.getInstance().fromHtml(summary).toString());
-        // Stato
-        manga.setFinished(getFirstMatchDefault("Stato</h(.+?)<h", source, "").contains("Completato"));
-        // Autor
-        manga.setAuthor(Util.getInstance().fromHtml(getFirstMatchDefault("Autore</h4>(.+?)<h4>", source, "")).toString().trim().replaceAll("\n", ""));
-        // Genere
-        manga.setGenre((Util.getInstance().fromHtml(getFirstMatchDefault("Genere</h4>(.+?)<h4>", source, "").replace("a><a", "a>, <a")).toString().trim()));
-        // Chapters
-        Pattern p = Pattern.compile("<tr.+?href=\"(/it/it-manga/.+?)\".+?>(.+?)</a", Pattern.DOTALL);
-        Matcher matcher = p.matcher(source);
-        ArrayList<Chapter> chapters = new ArrayList<>();
-        while (matcher.find()) {
-            chapters.add(0, new Chapter(Util.getInstance().fromHtml(matcher.group(2).replaceAll("Capitolo", " Cap ")).toString(), HOST + matcher.group(1)));
+        if (manga.getChapters().isEmpty() || forceReload) {
+            String source = getNavigatorAndFlushParameters().get(manga.getPath());
+            // Front
+            String image = getFirstMatchDefault("<div class=\"mangaImage2\"><img src=\"(.+?)\"", source, "");
+            if (image.length() > 2) {
+                image = "http:" + image;
+            }
+            manga.setImages(image);
+            // Summary
+            manga.setSynopsis(
+                    getFirstMatchDefault("mangaDescription\">(.+?)</h", source, context.getString(R.string.nodisponible)));
+            // Status
+            manga.setFinished(getFirstMatchDefault("Stato</h(.+?)<h", source, "").contains("Completato"));
+            // Author
+            manga.setAuthor(getFirstMatchDefault("Autore</h4>(.+?)<h4>", source, context.getString(R.string.nodisponible)));
+            // Genres
+            manga.setGenre(getFirstMatchDefault("Genere</h4>(.+?)<h4>", source, context.getString(R.string.nodisponible)));
+            // Chapters
+            Pattern pattern = Pattern.compile("<tr.+?href=\"(/it/it-manga/.+?)\".+?>(.+?)</a", Pattern.DOTALL);
+            Matcher matcher = pattern.matcher(source);
+            while (matcher.find()) {
+                Chapter chapter = new Chapter(matcher.group(2).replaceAll("Capitolo", " Cap "), HOST + matcher.group(1));
+                chapter.addChapterFirst(manga);
+            }
         }
-        manga.setChapters(chapters);
-    }
-
-    @Override
-    public String getPagesNumber(Chapter chapter, int page) {
-        return null;
-    }
-
-    @Override
-    public String getImageFrom(Chapter chapter, int page) throws Exception {
-        if (chapter.getExtra() == null || chapter.getExtra().length() < 2) {
-            setExtra(chapter);
-        }
-        return chapter.getExtra().split("\\|")[page];
-    }
-
-    private int setExtra(Chapter chapter) throws Exception {
-        int pages = 0;
-        String source = getNavigatorAndFlushParameters().get(chapter.getPath());
-        Pattern pattern = Pattern.compile("fs\":\\s*\"(.+?)\"", Pattern.DOTALL);
-        Matcher matcher = pattern.matcher(source);
-        String images = "";
-        while (matcher.find()) {
-            pages++;
-            //Log.d("ME", "1: " + "http:" + matcher.group(1));
-            images = images + "|" + "http:" + matcher.group(1);
-        }
-        chapter.setExtra(images);
-        return pages;
-    }
-
-    @Override
-    public void chapterInit(Chapter chapter) throws Exception {
-        if (chapter.getExtra() == null || chapter.getExtra().length() < 2) {
-            chapter.setPages(setExtra(chapter));
-        } else
-            chapter.setPages(0);
-    }
-
-    private ArrayList<Manga> getMangasFromSource(String source) {
-        Pattern p = Pattern.compile("<tr><td><a href=\"/it/it-manga/(.+?)\" class=\"(.+?)\">(.+?)</a>", Pattern.DOTALL);
-        Matcher m = p.matcher(source);
-        ArrayList<Manga> mangas = new ArrayList<>();
-        while (m.find()) {
-            Manga manga = new Manga(getServerID(), m.group(3), HOST + "it/it-manga/" +  m.group(1), m.group(2).contains("close"));
-            mangas.add(manga);
-        }
-        return mangas;
-    }
-
-    private ArrayList<Manga> getMangasFromFrontpage(String source) {
-        String newSource = "";
-        try {
-            newSource = getFirstMatchDefault("<ul id=\"news\"(.+?)</ul>", source, "");
-            //Log.d("ME","nS: "+newSource);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        Pattern pattern1 = Pattern.compile("<img src=\"(//cdn\\.mangaeden\\.com/mangasimg/.+?)\".+?<div class=\"hottestInfo\">[\\s]*<a href=\"(/it/it-manga/[^\"<>]+?)\" class=.+?\">(.+?)</a>", Pattern.DOTALL);
-        Matcher matcher1;
-        if (newSource.isEmpty())
-            matcher1 = pattern1.matcher(source);
-        else
-            matcher1 = pattern1.matcher(newSource);
-        ArrayList<Manga> mangas = new ArrayList<>();
-        int i = 0;
-        while (matcher1.find()) {
-            i++;
-            /*Log.d("ME", "(1): " + "http:" + matcher1.group(1));
-            Log.d("ME", "(2): " + matcher1.group(2));
-            Log.d("ME", "(3): " + matcher1.group(3));*/
-            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(matcher1.group(3)).toString(), HOST + matcher1.group(2), false);
-            manga.setImages("http:" + matcher1.group(1));
-            mangas.add(manga);
-            //Log.d("ME", "i: " + i);
-            if (newSource.isEmpty())
-                if (i == 40)
-                    break;
-        }
-        return mangas;
-    }
-
-    @Override
-    public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
-        String web = HOST + "it/it-directory/?author=&title=";
-        for (int i = 0; i < filters[3].length; i++) {
-            web = web + statusV[filters[3][i]];
-        }
-        for (int i = 0; i < filters[1].length; i++) {
-            web = web + "&categoriesInc=" + genreV[filters[1][i]];
-        }
-        for (int i = 0; i < filters[2].length; i++) {
-            web = web + "&categoriesExcl=" + genreV[filters[2][i]];
-        }
-        web = web + "&artist=";
-        for (int i = 0; i < filters[0].length; i++) {
-            web = web + typeV[filters[0][i]];
-        }
-        if (orderV[filters[4][0]].equals("")) {
-            web = "http://www.mangaeden.com/it/";
-            String source = getNavigatorAndFlushParameters().get(web);
-            return getMangasFromFrontpage(source);
-        } else {
-            web = web + orderV[filters[4][0]] + "&page=" + pageNumber;
-            String source = getNavigatorAndFlushParameters().get(web);
-            return getMangasFromSource(source);
-        }
-    }
-
-    @Override
-    public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{new ServerFilter("Type", type, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Included Genre(s)", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Excluded Genre(s)", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Status", status, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Order", order, ServerFilter.FilterType.SINGLE)
-        };
-    }
-
-    @Override
-    public boolean hasList() {
-        return false;
     }
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaHere.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaHere.java
@@ -2,6 +2,7 @@ package ar.rulosoft.mimanganu.servers;
 
 import android.content.Context;
 
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -10,8 +11,6 @@ import ar.rulosoft.mimanganu.R;
 import ar.rulosoft.mimanganu.componentes.Chapter;
 import ar.rulosoft.mimanganu.componentes.Manga;
 import ar.rulosoft.mimanganu.componentes.ServerFilter;
-import ar.rulosoft.mimanganu.utils.HtmlUnescape;
-import ar.rulosoft.mimanganu.utils.Util;
 
 class MangaHere extends ServerBase {
     private static final String HOST = "https://www.mangahere.co";
@@ -163,7 +162,7 @@ class MangaHere extends ServerBase {
             Pattern p = Pattern.compile(PATTERN_CHAPTERS, Pattern.DOTALL);
             Matcher m = p.matcher(data);
             while (m.find()) {
-                Chapter mc = new Chapter(Util.getInstance().fromHtml(m.group(2)).toString().trim(), "http:" + m.group(1));
+                Chapter mc = new Chapter(m.group(2), "http:" + m.group(1));
                 mc.addChapterFirst(manga);
             }
         }
@@ -188,7 +187,7 @@ class MangaHere extends ServerBase {
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
         String data;
-        data = getNavigatorAndFlushParameters().get(this.getPagesNumber(chapter, page));
+        data = getNavigatorAndFlushParameters().get(getPagesNumber(chapter, page));
         return getFirstMatch(PATTERN_IMAGE, data, "Error: failed to get the link to the image");
     }
 
@@ -221,7 +220,6 @@ class MangaHere extends ServerBase {
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
         ArrayList<Manga> mangas = new ArrayList<>();
         String web = HOST + "/" + valGenre[filters[0][0]] + "/" + pageNumber + ".htm" + orderM[filters[1][0]];
-        //Log.d("MH","web: "+web);
         String source = getNavigatorAndFlushParameters().get(web);
         Pattern p = Pattern.compile(PATTERN_MANGA, Pattern.DOTALL);
         Matcher m = p.matcher(source);
@@ -233,8 +231,8 @@ class MangaHere extends ServerBase {
             else {
                 path = m.group(3);
             }
-            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(m.group(2)).toString(), path, false);
-            manga.setImages(m.group(1));//.replace("thumb_", ""));
+            Manga manga = new Manga(getServerID(), m.group(2), path, false);
+            manga.setImages(m.group(1));
             mangas.add(manga);
         }
         hasMore = !mangas.isEmpty();
@@ -244,11 +242,11 @@ class MangaHere extends ServerBase {
     @Override
     public ArrayList<Manga> search(String term) throws Exception {
         ArrayList<Manga> mangas = new ArrayList<>();
-        String data = getNavigatorAndFlushParameters().get(HOST + "/search.php?name=" + term);
+        String data = getNavigatorAndFlushParameters().get(HOST + "/search.php?name=" + URLEncoder.encode(term, "UTF-8"));
         Pattern p = Pattern.compile(PATTERN_MANGA_SEARCHED, Pattern.DOTALL);
         Matcher m = p.matcher(data);
         while (m.find()) {
-            mangas.add(new Manga(getServerID(), HtmlUnescape.Unescape(m.group(2).trim()), "http:" + m.group(1), false));
+            mangas.add(new Manga(getServerID(), m.group(2), "http:" + m.group(1), false));
         }
         return mangas;
     }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaKawaii.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaKawaii.java
@@ -1,7 +1,7 @@
 package ar.rulosoft.mimanganu.servers;
 
 import android.content.Context;
-import android.util.Log;
+import android.text.TextUtils;
 
 import java.util.ArrayList;
 import java.util.regex.Matcher;
@@ -10,101 +10,79 @@ import java.util.regex.Pattern;
 import ar.rulosoft.mimanganu.R;
 import ar.rulosoft.mimanganu.componentes.Chapter;
 import ar.rulosoft.mimanganu.componentes.Manga;
-import ar.rulosoft.mimanganu.componentes.ServerFilter;
-import ar.rulosoft.mimanganu.utils.Util;
 
 /**
  * Created by xtj-9182 on 09.05.2017.
  */
 /* Je suis Charlie */
 class MangaKawaii extends ServerBase {
-    private static String HOST = "https://www.mangakawaii.com";
-    private static String[] genre = new String[]{
-            "All"
-    };
+    private static final String HOST = "https://www.mangakawaii.com";
 
     MangaKawaii(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_fr);
-        this.setIcon(R.drawable.mangakawaii);
-        this.setServerName("MangaKawaii");
-        setServerID(ServerBase.MANGAKAWAII);
+        setFlag(R.drawable.flag_fr);
+        setIcon(R.drawable.mangakawaii);
+        setServerName("MangaKawaii");
+        setServerID(MANGAKAWAII);
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
     }
 
     @Override
     public ArrayList<Manga> getMangas() throws Exception {
+        // FIXME a list of Manga could be retrieved using JavaScript
         return null;
     }
 
     @Override
     public ArrayList<Manga> search(String search) throws Exception {
-        ArrayList<Manga> mangas = new ArrayList<>();
-        String web = "https://www.mangakawaii.com/liste-mangas-texte";
-        String source = getNavigatorAndFlushParameters().get(web);
-        Pattern pattern = Pattern.compile("href=\"(https://www\\.mangakawaii\\.com/manga/[^\"]+?)\" style=\"display: inline-block\"><h6 style=\"margin: 0\">([^\"]+?)</h6></a>", Pattern.DOTALL); //manga-list(.+?)</ul>
-        Matcher matcher = pattern.matcher(source);
-        while (matcher.find()) {
-            /*Log.d("MKA", "1: " + matcher.group(1));
-            Log.d("MKA", "2: " + matcher.group(2));*/
-            if (matcher.group(2).toLowerCase().contains(search.toLowerCase())) {
-                    /*Log.d("MKA", "1: " + matcher.group(1));
-                    Log.d("MKA", "2: " + matcher.group(2));*/
-                Manga manga = new Manga(getServerID(), matcher.group(2), matcher.group(1), false);
-                mangas.add(manga);
-            }
-        }
-        return mangas;
+        // FIXME search functionality has to be implemented bases on Manga list
+        return null;
     }
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters() == null || manga.getChapters().size() == 0 || forceReload)
-            loadMangaInformation(manga, forceReload);
+        loadMangaInformation(manga, forceReload);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        String source = getNavigatorAndFlushParameters().get(manga.getPath());
+        if (manga.getChapters().isEmpty() || forceReload) {
+            String source = getNavigatorAndFlushParameters().get(manga.getPath());
 
-        // Cover
-        if (manga.getImages() == null || manga.getImages().isEmpty()) {
-            String img = getFirstMatchDefault("src='(https://www.mangakawaii.com/uploads/manga/[^\"]+?)'", source, "");
-            manga.setImages(img);
-        }
+            // Cover
+            if (manga.getImages() == null || manga.getImages().isEmpty()) {
+                String img = getFirstMatchDefault("src='(https://www.mangakawaii.com/uploads/manga/[^\"]+?)'", source, "");
+                manga.setImages(img);
+            }
 
-        // Summary
-        String summary = getFirstMatchDefault("id=\"synopsis\">[\\s]*<p>(.+?)</p>", source, "");
-        manga.setSynopsis(Util.getInstance().fromHtml(summary.trim()).toString());
+            // Summary
+            manga.setSynopsis(getFirstMatchDefault("id=\"synopsis\">[\\s]*<p>(.+?)</p>", source, context.getString(R.string.nodisponible)));
 
-        // Status
-        boolean status = !getFirstMatchDefault("Statut(.+?)</span>", source, "").contains("En Cours");
-        manga.setFinished(status);
+            // Status
+            manga.setFinished(!getFirstMatchDefault("Statut(.+?)</span>", source, "").contains("En Cours"));
 
-        // Author
-        String author = getFirstMatchDefault("author/.+?\">(.+?)</a>", source, "");
-        manga.setAuthor(author);
+            // Author
+            manga.setAuthor(getFirstMatchDefault("author/.+?\">(.+?)</a>", source, context.getString(R.string.nodisponible)));
 
-        // Genre
-        String genre = Util.getInstance().fromHtml(getFirstMatchDefault("Genres</span>(.+?)</span>", source, "")).toString();
-        //Log.d("MKA", "g: " + genre);
-        manga.setGenre(genre.replaceAll(",,",","));
+            // Genre
+            manga.setGenre(getFirstMatchDefault("Genres</span>(.+?)</span>", source, context.getString(R.string.nodisponible)));
 
-        // Chapters
-        Pattern p = Pattern.compile("href=\"(https://www\\.mangakawaii\\.com/manga/[^\"]+?)\">([^\"]+?)</a>", Pattern.DOTALL);
-        Matcher matcher = p.matcher(source);
-        ArrayList<Chapter> chapters = new ArrayList<>();
-        ArrayList<String> tmpChapterList = new ArrayList<>();
-        while (matcher.find()) {
-            /*Log.d("MKA", "(1): " + matcher.group(1));
-            Log.d("MKA", "(2): " + matcher.group(2));*/
-            if(!tmpChapterList.contains(matcher.group(1))) {
-                /*Log.d("MKA", "(1): " + matcher.group(1));
-                Log.d("MKA", "(2): " + matcher.group(2));*/
-                chapters.add(0, new Chapter(matcher.group(2), matcher.group(1)));
-                tmpChapterList.add(matcher.group(1));
+            // Chapters
+            Pattern p = Pattern.compile("href=\"(https://www\\.mangakawaii\\.com/manga/[^\"]+?)\">([^\"]+?)</a>", Pattern.DOTALL);
+            Matcher matcher = p.matcher(source);
+            ArrayList<String> tmpChapterList = new ArrayList<>();
+            while (matcher.find()) {
+                if(!tmpChapterList.contains(matcher.group(1))) {
+                    Chapter chapter = new Chapter(matcher.group(2), matcher.group(1));
+                    chapter.addChapterFirst(manga);
+                    tmpChapterList.add(matcher.group(1));
+                }
             }
         }
-        manga.setChapters(chapters);
     }
 
     @Override
@@ -121,70 +99,43 @@ class MangaKawaii extends ServerBase {
     }
 
     private int setExtra(Chapter chapter) throws Exception {
-        int pages = 0;
-        String source = "";
-        try {
-            source = getNavigatorAndFlushParameters().get(chapter.getPath());
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        String tmpImages = getFirstMatchDefault("<div id=\"all\"(.+?)</div>", source,"");
-        Pattern pattern = Pattern.compile("data-src='.(https://www\\.mangakawaii\\.com/uploads/[^\"]+?).'", Pattern.DOTALL);
-        Matcher matcher = pattern.matcher(tmpImages);
-        String images = "";
-        while (matcher.find()) {
-            pages++;
-            //Log.d("MKA", "1: " + matcher.group(1));
-            images = images + "|" + matcher.group(1);
-        }
-        chapter.setExtra(images);
-        return pages;
+        String source = getNavigatorAndFlushParameters().get(chapter.getPath());
+        String tmpImages = getFirstMatchDefault("<div id=\"all\"(.+?)</div>", source, "");
+
+        ArrayList<String> matches = getAllMatch("data-src='.(https://www\\.mangakawaii\\.com/uploads/[^\"]+?).'", tmpImages);
+        chapter.setExtra(TextUtils.join("|", matches));
+
+        return matches.size();
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
         if (chapter.getExtra() == null || chapter.getExtra().length() < 2) {
             chapter.setPages(setExtra(chapter));
-        } else
+        } else {
             chapter.setPages(0);
-    }
-
-    @Override
-    public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{
-                new ServerFilter("Genre(s)", genre, ServerFilter.FilterType.SINGLE),
-        };
-    }
-
-    private ArrayList<Manga> getMangasFromSource(String source) {
-        Pattern pattern = Pattern.compile("(<img w.+? (class=\"thumbnail\">|inline-block;\", Pattern.DOTALL))");
-        Matcher matcher = pattern.matcher(source);
-        ArrayList<Manga> mangas = new ArrayList<>();
-        while (matcher.find()) {
-            /*Log.d("MKA", "(0): " + matcher.group(1));
-            Log.d("MKA", "(1): " + getFirstMatchDefault("href=\"([^\"]+?)\"", matcher.group(1), ""));
-            Log.d("MKA", "(2): " + getFirstMatchDefault("src='([^\"]+?)'", matcher.group(1), ""));
-            Log.d("MKA", "(3): " + getFirstMatchDefault("alt='([^\"]+?)'", matcher.group(1), ""));*/
-            Manga m = new Manga(getServerID(), getFirstMatchDefault("alt='([^\"]+?)'", matcher.group(1), ""), getFirstMatchDefault("href=\"([^\"]+?)\"", matcher.group(1), ""), false);
-            m.setImages(getFirstMatchDefault("src='([^\"]+?)'", matcher.group(1), ""));
-            mangas.add(m);
         }
-        return mangas;
     }
 
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
-        String web = "https://www.mangakawaii.com/liste-mangas?page=" + pageNumber;
-        Log.d("MKA", "web: " + web);
-        String source = getNavigatorAndFlushParameters().get(web);
-        if (source.isEmpty()) // page 3 is broken for some reason ¯\_(ツ)_/¯
-            source = getNavigatorAndFlushParameters().get(web + (pageNumber + 1));
-        return getMangasFromSource(source);
-    }
+        // TODO implement filtering
 
-    @Override
-    public boolean hasList() {
-        return false;
+        String web = HOST + "/liste-mangas?page=" + pageNumber;
+        String source = getNavigatorAndFlushParameters().get(web);
+
+        Pattern pattern = Pattern.compile("<div class=\"media-left\">(.+?)</div>", Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(source);
+        ArrayList<Manga> mangas = new ArrayList<>();
+        while (matcher.find()) {
+            Manga m = new Manga(getServerID(),
+                    getFirstMatchDefault("alt='([^']+)", matcher.group(1), ""),
+                    getFirstMatchDefault("href=\"([^\"]+)", matcher.group(1), ""),
+                    false
+            );
+            m.setImages(getFirstMatchDefault("src='([^\']+)", matcher.group(1), ""));
+            mangas.add(m);
+        }
+        return mangas;
     }
 }
-

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaKawaii.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaKawaii.java
@@ -38,6 +38,11 @@ class MangaKawaii extends ServerBase {
     }
 
     @Override
+    public boolean hasSearch() {
+        return false;
+    }
+
+    @Override
     public ArrayList<Manga> search(String search) throws Exception {
         // FIXME search functionality has to be implemented bases on Manga list
         return null;

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaPanda.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaPanda.java
@@ -12,7 +12,8 @@ import ar.rulosoft.mimanganu.componentes.Manga;
 import ar.rulosoft.mimanganu.componentes.ServerFilter;
 import ar.rulosoft.mimanganu.utils.Util;
 
-public class MangaPanda extends ServerBase {
+class MangaPanda extends ServerBase {
+    private static String HOST = "http://www.mangapanda.com";
 
     private static final String PATTERN_SERIE =
             "<li><a href=\"([^\"]+)\">([^<]+)";
@@ -24,51 +25,95 @@ public class MangaPanda extends ServerBase {
             "<a href=\"([^\"]+)\">([^\"]+?)</a>.:([^\"]+?)</td>";
     private static final String PATTERN_CHAPTER_WEB =
             "/[-|\\d]+/([^/]+)/chapter-(\\d+).html";
-    private static String HOST = "http://www.mangapanda.com";
-    private static String[] genre = new String[]{
-            "Action", "Adventure", "Comedy", "Demons", "Drama", "Ecchi",
-            "Fantasy", "Gender bender", "Harem", "Historical", "Horror",
-            "Josei", "Magic", "Martial arts", "Mature", "Mecha", "Military",
-            "Mystery", "One Shot", "Psychological", "Romance", "School life",
-            "Sci-fi", "Seinen", "Shoujo", "Shoujoai", "Shounen", "Shounenai",
-            "Slice of Life", "Smut", "Sports", "Super Power", "Supernatural",
-            "Tragedy", "Vampire", "Yaoi", "Yuri"
+
+    private static int[] fltGenre = {
+            R.string.flt_tag_action,
+            R.string.flt_tag_adventure,
+            R.string.flt_tag_comedy,
+            R.string.flt_tag_daemons,
+            R.string.flt_tag_drama,
+            R.string.flt_tag_ecchi,
+            R.string.flt_tag_fantasy,
+            R.string.flt_tag_gender_bender,
+            R.string.flt_tag_harem,
+            R.string.flt_tag_historical,
+            R.string.flt_tag_horror,
+            R.string.flt_tag_josei,
+            R.string.flt_tag_magic,
+            R.string.flt_tag_martial_arts,
+            R.string.flt_tag_mature,
+            R.string.flt_tag_mecha,
+            R.string.flt_tag_military,
+            R.string.flt_tag_mystery,
+            R.string.flt_tag_one_shot,
+            R.string.flt_tag_psychological,
+            R.string.flt_tag_romance,
+            R.string.flt_tag_school_life,
+            R.string.flt_tag_sci_fi,
+            R.string.flt_tag_seinen,
+            R.string.flt_tag_shoujo,
+            R.string.flt_tag_shoujo_ai,
+            R.string.flt_tag_shounen,
+            R.string.flt_tag_shounen_ai,
+            R.string.flt_tag_slice_of_life,
+            R.string.flt_tag_smut,
+            R.string.flt_tag_sports,
+            R.string.flt_tag_super_powers,
+            R.string.flt_tag_supernatural,
+            R.string.flt_tag_tragedy,
+            R.string.flt_tag_vampire,
+            R.string.flt_tag_yaoi,
+            R.string.flt_tag_yuri
     };
 
-    private static String[] type = new String[]{
-            "Both", "Manhwa", "Manga"
+    private static final int[] fltType = {
+            R.string.flt_tag_all,
+            R.string.flt_tag_manga,
+            R.string.flt_tag_manhwa,
+    };
+    private static final String[] valType = {
+            "&rd=0",
+            "&rd=2",
+            "&rd=1"
     };
 
-    private static String[] typeV = new String[]{
-            "&rd=0", "&rd=1", "&rd=2"
+    private static final int[] fltStatus = {
+            R.string.flt_status_all,
+            R.string.flt_status_ongoing,
+            R.string.flt_status_completed
+    };
+    private static final String[] valStatus = {
+            "&status=",
+            "&status=1",
+            "&status=2"
     };
 
-    private static String[] status = new String[]{
-            "Both", "Ongoing", "Completed"
+    private static final int[] fltOrder = {
+            R.string.flt_order_views,
+            R.string.flt_order_alpha,
+            R.string.flt_order_similar
     };
-
-    private static String[] statusV = new String[]{
-            "&status=", "&status=1", "&status=2"
+    private static final String[] valOrder = {
+            "&order=2",
+            "&order=1",
+            "&order="
     };
-
-    private static String[] order = new String[]{
-            "Popularity", "Alphabetical", "Similarity"
-    };
-    private static String[] orderV = new String[]{
-            "&order=2", "&order=1", "&order="
-    };
-
 
     MangaPanda(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_en);
-        this.setIcon(R.drawable.mangapanda_icon);
-        this.setServerName("Mangapanda.com");
-        setServerID(ServerBase.MANGAPANDA);
+        setFlag(R.drawable.flag_en);
+        setIcon(R.drawable.mangapanda_icon);
+        setServerName("mangapanda");
+        setServerID(MANGAPANDA);
     }
 
     void SetHost(String new_host) {
         HOST = new_host;
+    }
+
+    @Override
+    public boolean hasList() {
+        return true;
     }
 
     @Override
@@ -82,8 +127,7 @@ public class MangaPanda extends ServerBase {
             Pattern p1 = Pattern.compile(PATTERN_SERIE, Pattern.DOTALL);
             Matcher m1 = p1.matcher(b);
             while (m1.find()) {
-                mangas.add(new Manga(this.getServerID(), m1.group(2),
-                        HOST + m1.group(1), false));
+                mangas.add(new Manga(this.getServerID(), m1.group(2), HOST + m1.group(1), false));
             }
         }
         return mangas;
@@ -96,80 +140,92 @@ public class MangaPanda extends ServerBase {
         Pattern p = Pattern.compile("(.+?)\\|.+?\\|(/.+?)\\|\\d+", Pattern.DOTALL);
         Matcher m = p.matcher(data);
         while (m.find()) {
-            mangas.add(new Manga(getServerID(), m.group(1).trim(),
-                    HOST + m.group(2), false));
+            mangas.add(new Manga(getServerID(), m.group(1), HOST + m.group(2), false));
         }
         return mangas;
     }
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters() == null || manga.getChapters().size() == 0 ||
-                forceReload) loadMangaInformation(manga, forceReload);
+        loadMangaInformation(manga, forceReload);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        String data = getNavigatorAndFlushParameters().get(manga.getPath());
-        Pattern p = Pattern.compile(PATTERN_FRAG_CHAPTER, Pattern.DOTALL);
-        Matcher m = p.matcher(data);
-        if (m.find()) {
-            manga.getChapters().clear();
-            Pattern p1 = Pattern.compile(PATTERN_CHAPTER, Pattern.DOTALL);
-            Matcher m1 = p1.matcher(m.group(1));
-            while (m1.find()) {
-                String web = m1.group(1);
-                if (web.matches(PATTERN_CHAPTER_WEB)) {
-                    Pattern p2 = Pattern.compile(PATTERN_CHAPTER_WEB, Pattern.DOTALL);
-                    Matcher m2 = p2.matcher(web);
-                    if (m2.find()) web = m2.group(1) + "/" + m2.group(2);
+        if (manga.getChapters().isEmpty() || forceReload) {
+            String data = getNavigatorAndFlushParameters().get(manga.getPath());
+            Pattern p = Pattern.compile(PATTERN_FRAG_CHAPTER, Pattern.DOTALL);
+            Matcher m = p.matcher(data);
+            if (m.find()) {
+                manga.getChapters().clear();
+                Pattern p1 = Pattern.compile(PATTERN_CHAPTER, Pattern.DOTALL);
+                Matcher m1 = p1.matcher(m.group(1));
+                while (m1.find()) {
+                    String web = m1.group(1);
+                    if (web.matches(PATTERN_CHAPTER_WEB)) {
+                        Pattern p2 = Pattern.compile(PATTERN_CHAPTER_WEB, Pattern.DOTALL);
+                        Matcher m2 = p2.matcher(web);
+                        if (m2.find()) web = m2.group(1) + "/" + m2.group(2);
+                    }
+                    String chName = m1.group(2);
+                    if (!m1.group(3).trim().isEmpty())
+                        chName += " :" + m1.group(3);
+                    manga.addChapter(new Chapter(chName, HOST + web));
                 }
-                String chName = m1.group(2);
-                if (!m1.group(3).trim().isEmpty())
-                    chName += " :" + m1.group(3);
-                manga.addChapter(new Chapter(chName, HOST + web));
             }
+            // Summary
+            manga.setSynopsis(getFirstMatchDefault("<p>(.+)</p>", data, context.getString(R.string.nodisponible)));
+            // Cover
+            manga.setImages(getFirstMatchDefault("mangaimg\"><img src=\"([^\"]+)", data, ""));
+            // Status
+            manga.setFinished(data.contains("<td>Completed</td>"));
+            // Genre
+            manga.setGenre(getFirstMatchDefault("Genre:</td>[^<]*<td>(.+?)</td>", data, context.getString(R.string.nodisponible)).replace("a> <a", "a>, <a"));
+            // Author
+            manga.setAuthor(getFirstMatchDefault("Author:</td>[^<]*<td>([^<]+)", data, context.getString(R.string.nodisponible)));
         }
-        // Summary
-        manga.setSynopsis(getFirstMatchDefault("<p>(.+)</p>", data, defaultSynopsis));
-        // Title
-        manga.setImages(getFirstMatchDefault("mangaimg\"><img src=\"([^\"]+)", data, ""));
-        // Status
-        manga.setFinished(data.contains("</td><td>Completed</td>"));
-        // Genre
-        manga.setGenre(Util.getInstance().fromHtml(getFirstMatchDefault("Genre:</td><td>(.+?)</td>", data, "").replace("a> <a", "a>, <a")).toString());
-        // Author
-        manga.setAuthor(Util.getInstance().fromHtml(getFirstMatchDefault("Author:</td><td>(.+?)<", data, "")).toString());
     }
 
     @Override
     public String getPagesNumber(Chapter chapter, int page) {
-        page = (page > chapter.getPages()) ? 1 : page;
+        if (page < 1) {
+            page = 1;
+        }
+        if (page > chapter.getPages()) {
+            page = chapter.getPages();
+        }
         return chapter.getPath() + "/" + page;
     }
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
-        String data;
-        data = getNavigatorAndFlushParameters().get(this.getPagesNumber(chapter, page));
-        return getFirstMatch("src=\"([^\"]+?.(jpg|gif|jpeg|png|bmp))", data, "Error: Could not get the link to the image");
+        String data = getNavigatorAndFlushParameters().get(getPagesNumber(chapter, page));
+        return getFirstMatch("src=\"([^\"]+?.(jpg|gif|jpeg|png|bmp))", data, "Error: failed to get the link to the image");
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
-        String data;
-        data = getNavigatorAndFlushParameters().get(chapter.getPath());
-        String pages =
-                getFirstMatch("of (\\d+)</div>", data, "Error: Could not get the number of pages");
+        String data = getNavigatorAndFlushParameters().get(chapter.getPath());
+        String pages = getFirstMatch("of (\\d+)</div>", data, "Error: failed to get the number of pages");
         chapter.setPages(Integer.parseInt(pages));
     }
 
     @Override
     public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{new ServerFilter("Genre", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Manga Type", type, ServerFilter.FilterType.SINGLE),
-                new ServerFilter("Manga Status", status, ServerFilter.FilterType.SINGLE),
-                new ServerFilter("Sorting Order", order, ServerFilter.FilterType.SINGLE)};
+        return new ServerFilter[]{
+                new ServerFilter(
+                        context.getString(R.string.flt_genre),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_type),
+                        buildTranslatedStringArray(fltType), ServerFilter.FilterType.SINGLE),
+                new ServerFilter(
+                        context.getString(R.string.flt_status),
+                        buildTranslatedStringArray(fltStatus), ServerFilter.FilterType.SINGLE),
+                new ServerFilter(
+                        context.getString(R.string.flt_order),
+                        buildTranslatedStringArray(fltOrder), ServerFilter.FilterType.SINGLE),
+        };
     }
 
     ///search/?w=&rd=0&status=0&order=0&genre=1000010000000000000000000000000000000&p=0
@@ -177,7 +233,7 @@ public class MangaPanda extends ServerBase {
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
         String gens = "";
-        for (int i = 0; i < genre.length; i++) {
+        for (int i = 0; i < fltGenre.length; i++) {
             if (Util.getInstance().contains(filters[0], i)) {
                 gens = gens + "1";
             } else {
@@ -185,7 +241,7 @@ public class MangaPanda extends ServerBase {
             }
         }
         ArrayList<Manga> mangas = new ArrayList<>();
-        String web = HOST + "/search/?w=" + typeV[filters[1][0]] + statusV[filters[2][0]] + orderV[filters[3][0]] + "&genre=" + gens + "&p=" + ((pageNumber - 1) * 30);
+        String web = HOST + "/search/?w=" + valType[filters[1][0]] + valStatus[filters[2][0]] + valOrder[filters[3][0]] + "&genre=" + gens + "&p=" + ((pageNumber - 1) * 30);
         String data = getNavigatorAndFlushParameters().get(web);
         Pattern p = Pattern.compile("(http:[^']+/cover/.+?)'.+?<h3><a href=\"(.+?)\">(.+?)<", Pattern.DOTALL);
         Matcher m = p.matcher(data);
@@ -196,10 +252,4 @@ public class MangaPanda extends ServerBase {
         }
         return mangas;
     }
-
-    @Override
-    public boolean hasList() {
-        return true;
-    }
-
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaReader.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaReader.java
@@ -16,10 +16,10 @@ public class MangaReader extends MangaPanda {
      */
     public MangaReader(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_en);
-        this.setIcon(R.drawable.mangareader);
-        this.setServerName("Mangareader.net");
-        setServerID(ServerBase.MANGAREADER);
+        setFlag(R.drawable.flag_en);
+        setIcon(R.drawable.mangareader);
+        setServerName("mangareader.net");
+        setServerID(MANGAREADER);
 
         SetHost("http://www.mangareader.net");
     }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaStream.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaStream.java
@@ -155,4 +155,9 @@ class MangaStream extends ServerBase {
         }
         return mangas;
     }
+
+    @Override
+    public FilteredType getFilteredType() {
+        return FilteredType.TEXT;
+    }
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaTown.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaTown.java
@@ -11,7 +11,6 @@ import ar.rulosoft.mimanganu.R;
 import ar.rulosoft.mimanganu.componentes.Chapter;
 import ar.rulosoft.mimanganu.componentes.Manga;
 import ar.rulosoft.mimanganu.componentes.ServerFilter;
-import ar.rulosoft.mimanganu.utils.HtmlUnescape;
 import ar.rulosoft.mimanganu.utils.Util;
 
 class MangaTown extends ServerBase {
@@ -165,7 +164,7 @@ class MangaTown extends ServerBase {
             Pattern p = Pattern.compile(PATTERN_CHAPTER, Pattern.DOTALL);
             Matcher m = p.matcher(data);
             while (m.find()) {
-                Chapter mc = new Chapter(Util.getInstance().fromHtml(m.group(2)).toString().trim(), "http:" + m.group(1));
+                Chapter mc = new Chapter(m.group(2), "http:" + m.group(1));
                 mc.addChapterFirst(manga);
             }
         }
@@ -211,7 +210,7 @@ class MangaTown extends ServerBase {
         Pattern p = Pattern.compile(PATTERN_MANGA, Pattern.DOTALL);
         Matcher m = p.matcher(data);
         while (m.find()) {
-            mangas.add(new Manga(getServerID(), HtmlUnescape.Unescape(m.group(2).trim()), "https:" + m.group(1), false));
+            mangas.add(new Manga(getServerID(), m.group(2), "https:" + m.group(1), false));
         }
         return mangas;
     }
@@ -272,7 +271,7 @@ class MangaTown extends ServerBase {
         Matcher m = p.matcher(data);
         while (m.find()) {
             Manga manga = new Manga(
-                    getServerID(), HtmlUnescape.Unescape(m.group(2)), "https:" + m.group(1), false);
+                    getServerID(), m.group(2), "https:" + m.group(1), false);
             manga.setImages(m.group(3));
             mangas.add(manga);
         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/Mangapedia.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/Mangapedia.java
@@ -1,11 +1,10 @@
 package ar.rulosoft.mimanganu.servers;
 
 import android.content.Context;
-import android.provider.ContactsContract;
+import android.text.TextUtils;
 
+import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -20,55 +19,136 @@ import okhttp3.MultipartBody;
 /**
  * Created by Raúl on 15/07/2017.
  */
+class Mangapedia extends ServerBase {
 
-public class Mangapedia extends ServerBase {
+    private static final String HOST = "http://mangapedia.fr/";
 
-    private static final String[] genre = {"Shonen", "Seinen", "Shonen Ai", "Josei"
-            , "Shojo", "Shojo Ai", "Yaoi", "Yuri"};
-
-    private static final String[] genreV = {
-            "typeID[1]","typeID[2]","typeID[3]","typeID[4]","typeID[5]","typeID[6]",
-            "typeID[7]","typeID[8]",
+    private static final int[] fltDemographic = {
+            R.string.flt_tag_shounen,
+            R.string.flt_tag_seinen,
+            R.string.flt_tag_shounen_ai,
+            R.string.flt_tag_josei,
+            R.string.flt_tag_shoujo,
+            R.string.flt_tag_shoujo_ai,
+            R.string.flt_tag_yaoi,
+            R.string.flt_tag_yuri,
+    };
+    private static final String[] valDemographic = {
+            "typeID[1]",
+            "typeID[2]",
+            "typeID[3]",
+            "typeID[4]",
+            "typeID[5]",
+            "typeID[6]",
+            "typeID[7]",
+            "typeID[8]",
     };
 
-    private static final String[] subGenre = {
-            "Action","Aventure","Comédie","Drame","Fantasie","Arts Martiaux",
-            "Mystères","Surnaturel","Adulte","Doujinshi","Ecchi","Harem",
-            "Historique","Horreur","Mature","Mecha","One Shot","Psychologie",
-            "Romance","School Life","Sci-Fi","Tranche de vie","Sports","Tragédie",
-
+    private static final int[] fltGenre = {
+            R.string.flt_tag_action, //Action
+            R.string.flt_tag_adventure, //Aventure
+            R.string.flt_tag_comedy, //Comédie
+            R.string.flt_tag_drama, //Drame
+            R.string.flt_tag_fantasy, //Fantasie
+            R.string.flt_tag_martial_arts, //Arts Martiaux
+            R.string.flt_tag_mystery, //Mystères
+            R.string.flt_tag_supernatural, //Surnaturel
+            R.string.flt_tag_adult, //Adulte
+            R.string.flt_tag_doujinshi, //Doujinshi
+            R.string.flt_tag_ecchi, //Ecchi
+            R.string.flt_tag_harem, //Harem
+            R.string.flt_tag_historical, //Historique
+            R.string.flt_tag_horror, //Horreur
+            R.string.flt_tag_mature, //Mature
+            R.string.flt_tag_mecha, //Mecha
+            R.string.flt_tag_one_shot, //One Shot
+            R.string.flt_tag_psychological, //Psychologie
+            R.string.flt_tag_romance, //Romance
+            R.string.flt_tag_school_life, //School Life
+            R.string.flt_tag_sci_fi, //Sci-Fi
+            R.string.flt_tag_slice_of_life, //Tranche de vie
+            R.string.flt_tag_sports, //Sports
+            R.string.flt_tag_tragedy, //Tragédie
     };
-    private static final String[] subGenreV = {
-            "categoryID[1]","categoryID[2]","categoryID[3]","categoryID[4]","categoryID[5]","categoryID[6]",
-            "categoryID[7]","categoryID[8]","categoryID[9]","categoryID[10]","categoryID[11]","categoryID[12]",
-            "categoryID[13]","categoryID[14]","categoryID[15]","categoryID[16]","categoryID[17]","categoryID[18]",
-            "categoryID[19]","categoryID[20]","categoryID[21]","categoryID[22]","categoryID[23]","categoryID[24]"
+    private static final String[] valGenre = {
+            "categoryID[1]",
+            "categoryID[2]",
+            "categoryID[3]",
+            "categoryID[4]",
+            "categoryID[5]",
+            "categoryID[6]",
+            "categoryID[7]",
+            "categoryID[8]",
+            "categoryID[9]",
+            "categoryID[10]",
+            "categoryID[11]",
+            "categoryID[12]",
+            "categoryID[13]",
+            "categoryID[14]",
+            "categoryID[15]",
+            "categoryID[16]",
+            "categoryID[17]",
+            "categoryID[18]",
+            "categoryID[19]",
+            "categoryID[20]",
+            "categoryID[21]",
+            "categoryID[22]",
+            "categoryID[23]",
+            "categoryID[24]",
     };
 
-    private static final String[] type = {"Manga", "Manhwa", "Manhua", "Webcomics"};
-
-    private static final String[] typeV = {
-            "typeBookID[1]", "typeBookID[2]", "typeBookID[4]", "typeBookID[5]"
+    private static final int[] fltType = {
+            R.string.flt_tag_manga, //Manga
+            R.string.flt_tag_manhwa, //Manhwa
+            R.string.flt_tag_manhua, //Manhua
+            R.string.flt_tag_webcomic, //Webcomics
+    };
+    private static final String[] valType = {
+            "typeBookID[1]",
+            "typeBookID[2]",
+            "typeBookID[4]",
+            "typeBookID[5]"
     };
 
-    private static final String[] sortBy = {"Default", "Titre", "Auteur", "Illustrateur", "Vues", "Derniere MAJ"};
-
-    private static final String[] sortByV = {
-            "0", "1", "2", "3", "4", "5"
+    private static final int[] fltSortBy = {
+            R.string.flt_order_default, //Default
+            R.string.flt_order_title, //Titre
+            R.string.flt_order_author, //Auteur
+            R.string.flt_order_artist, //Illustrateur
+            R.string.flt_order_views, //Vues
+            R.string.flt_order_last_update, //Derniere MAJ
+    };
+    private static final String[] valSortBy = {
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5"
     };
 
-    private static final String[] sortOrder = {"Default", "Croissant", "Décroissant"};
-
-    private static final String[] sortOrderV = {
-            "0", "1", "2"
+    private static final int[] fltSortOrder = {
+            R.string.flt_order_default, //Default
+            R.string.flt_order_ascending, //Croissant
+            R.string.flt_order_descending, //Décroissant
+    };
+    private static final String[] valSortOrder = {
+            "0",
+            "1",
+            "2"
     };
 
-    public Mangapedia(Context context) {
+    Mangapedia(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_fr);
-        this.setIcon(R.drawable.mangapedia);
-        this.setServerName("Mangapedia");
-        setServerID(ServerBase.MANGAPEDIA);
+        setFlag(R.drawable.flag_fr);
+        setIcon(R.drawable.mangapedia);
+        setServerName("Mangapedia");
+        setServerID(MANGAPEDIA);
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
     }
 
     @Override
@@ -78,9 +158,9 @@ public class Mangapedia extends ServerBase {
 
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
-        String web = "http://mangapedia.fr/project_code/script/moreMangas.php";
-        if(pageNumber == 1){
-            web = "http://mangapedia.fr/project_code/script/search.php";
+        String web = HOST + "/project_code/script/moreMangas.php";
+        if (pageNumber == 1) {
+            web = HOST + "/project_code/script/search.php";
         }
 
         Navigator nav = getNavigatorAndFlushParameters();
@@ -88,44 +168,47 @@ public class Mangapedia extends ServerBase {
         nav.addHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
         nav.addHeader("X-Requested-With", "XMLHttpRequest");
         MultipartBody.Builder mBodyBuilder = new MultipartBody.Builder(boundary).setType(MultipartBody.FORM);
-        mBodyBuilder.addFormDataPart("artist","");
-        mBodyBuilder.addFormDataPart("searchType","advance");
+        mBodyBuilder.addFormDataPart("artist", "");
+        mBodyBuilder.addFormDataPart("searchType", "advance");
         mBodyBuilder.addFormDataPart("pageNumber", "" + pageNumber);
-        mBodyBuilder.addFormDataPart("searchTerm","");
-        mBodyBuilder.addFormDataPart("searchByLetter","");
-        for(int i = 0; i < genreV.length; i++){
-            if(Util.getInstance().contains(filters[0],i)){
-                mBodyBuilder.addFormDataPart(genreV[i],"1");
-            }else{
-                mBodyBuilder.addFormDataPart(genreV[i],"0");
+        mBodyBuilder.addFormDataPart("searchTerm", "");
+        mBodyBuilder.addFormDataPart("searchByLetter", "");
+        for (int i = 0; i < valDemographic.length; i++) {
+            if (Util.getInstance().contains(filters[0], i)) {
+                mBodyBuilder.addFormDataPart(valDemographic[i], "1");
+            } else {
+                mBodyBuilder.addFormDataPart(valDemographic[i], "0");
             }
         }
-        for(int i = 0; i < subGenreV.length; i++){
-            if(Util.getInstance().contains(filters[1],i)){
-                mBodyBuilder.addFormDataPart(subGenreV[i],"1");
-            }else{
-                mBodyBuilder.addFormDataPart(subGenreV[i],"0");
+        for (int i = 0; i < valGenre.length; i++) {
+            if (Util.getInstance().contains(filters[1], i)) {
+                mBodyBuilder.addFormDataPart(valGenre[i], "1");
+            } else {
+                mBodyBuilder.addFormDataPart(valGenre[i], "0");
             }
         }
-        for(int i = 0; i < typeV.length; i++){
-            if(Util.getInstance().contains(filters[2],i)){
-                mBodyBuilder.addFormDataPart(typeV[i],"1");
-            }else{
-                mBodyBuilder.addFormDataPart(typeV[i],"0");
+        for (int i = 0; i < valType.length; i++) {
+            if (Util.getInstance().contains(filters[2], i)) {
+                mBodyBuilder.addFormDataPart(valType[i], "1");
+            } else {
+                mBodyBuilder.addFormDataPart(valType[i], "0");
             }
         }
-        mBodyBuilder.addFormDataPart("sortBy", sortByV[filters[3][0]]);
-        mBodyBuilder.addFormDataPart("sortOrder", sortOrderV[filters[4][0]]);
-        return getMangasString(nav.post(web, mBodyBuilder.build()));
+        mBodyBuilder.addFormDataPart("sortBy", valSortBy[filters[3][0]]);
+        mBodyBuilder.addFormDataPart("sortOrder", valSortOrder[filters[4][0]]);
+
+        ArrayList<Manga> mangas = getMangasString(nav.post(web, mBodyBuilder.build()));
+        hasMore = !mangas.isEmpty();
+        return mangas;
     }
 
-    private ArrayList<Manga> getMangasString(String data){
+    private ArrayList<Manga> getMangasString(String data) {
         ArrayList<Manga> mangas = new ArrayList<>();
-        Pattern p = Pattern.compile("<a href=\"([^\"]+)\".+?src=\"([^\"]+)\"\\/>.+?>(.+?)<", Pattern.DOTALL);
+        Pattern p = Pattern.compile("<a href=\"([^\"]+)\".+?src=\"([^\"]+)\"\\s*/>.+?>(.+?)<");
         Matcher m = p.matcher(data);
         while (m.find()) {
             Manga manga = new Manga(getServerID(), m.group(3), m.group(1), false);
-            manga.setImages(m.group(2).replaceAll("-thumb","")+"|http://mangapedia.fr/mangas");
+            manga.setImages(m.group(2).replaceAll("-thumb", "") + "|" + HOST + "/mangas");
             mangas.add(manga);
         }
         return mangas;
@@ -133,72 +216,60 @@ public class Mangapedia extends ServerBase {
 
     @Override
     public ServerFilter[] getServerFilters() {
-        return  new ServerFilter[]{
-                new ServerFilter("Genres", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Sub Genre", subGenre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Type", type, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Classé par", sortBy, ServerFilter.FilterType.SINGLE),
-                new ServerFilter("Classé par", sortOrder , ServerFilter.FilterType.SINGLE)};
+        return new ServerFilter[]{
+                new ServerFilter(
+                        context.getString(R.string.flt_demographic),
+                        buildTranslatedStringArray(fltDemographic), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_genre),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_type),
+                        buildTranslatedStringArray(fltType), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_order_by),
+                        buildTranslatedStringArray(fltSortBy), ServerFilter.FilterType.SINGLE),
+                new ServerFilter(
+                        context.getString(R.string.flt_order),
+                        buildTranslatedStringArray(fltSortOrder), ServerFilter.FilterType.SINGLE)};
     }
 
     @Override
     public ArrayList<Manga> search(String term) throws Exception {
         Navigator nav = getNavigatorAndFlushParameters();
-        String boundary = Navigator.getNewBoundary();
-        nav.addHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
-        nav.addHeader("X-Requested-With", "XMLHttpRequest");
-        MultipartBody.Builder mBodyBuilder = new MultipartBody.Builder(boundary).setType(MultipartBody.FORM);
-        mBodyBuilder.addFormDataPart("artist",term);
-        mBodyBuilder.addFormDataPart("searchType","advance");
-        mBodyBuilder.addFormDataPart("pageNumber", "1");
-        mBodyBuilder.addFormDataPart("searchTerm","");
-        mBodyBuilder.addFormDataPart("searchByLetter","");
-        for(int i = 0; i < genreV.length; i++){
-            mBodyBuilder.addFormDataPart(genreV[i],"0");
-        }
-        for(int i = 0; i < subGenreV.length; i++){
-            mBodyBuilder.addFormDataPart(subGenreV[i],"0");
-        }
-        for(int i = 0; i < typeV.length; i++){
-            mBodyBuilder.addFormDataPart(typeV[i],"0");
-
-        }
-        mBodyBuilder.addFormDataPart("sortBy", "0");
-        mBodyBuilder.addFormDataPart("sortOrder", "0");
-        return getMangasString(nav.post("http://mangapedia.fr/project_code/script/search.php", mBodyBuilder.build()));    }
+        return getMangasString(nav.get(HOST + "/mangas/" + URLEncoder.encode(term, "UTF-8").replaceAll(" ", "%25")));
+    }
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        loadMangaInformation(manga,forceReload);
+        loadMangaInformation(manga, forceReload);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters().size() == 0 || forceReload) {
+        if (manga.getChapters().isEmpty() || forceReload) {
             String data = getNavigatorAndFlushParameters().get(manga.getPath());
-            //Autor
-            manga.setAuthor(Util.getInstance().fromHtml(
-                    getFirstMatchDefault("Auteur : (.+?)</div>", data,
-                            context.getString(R.string.nodisponible))).toString());
-            //Generos
-            manga.setGenre(Util.getInstance().fromHtml(
-                    getFirstMatchDefault("Sous-genres : (.+?)<\\/div>", data,
-                            context.getString(R.string.nodisponible))).toString());
-
-            //Sinopsis
-            manga.setSynopsis(Util.getInstance().fromHtml(
-                    getFirstMatchDefault("Synopsis : (.+?)<\\/div>", data,
-                            context.getString(R.string.nodisponible))).toString());
-            //Estado
-            manga.setFinished(!getFirstMatchDefault("Statut : (.+?)<\\/div>", data, "en cours")
-                    .contains("en cours"));
-            //Capítulos
-            manga.getChapters().clear();
+            // Cover
+            if(manga.getImages() == null) {
+                manga.setImages(
+                        getFirstMatchDefault("<div id=\"mangaImage\">\\s*<img src=\"([^\"]+)\"", data, "")
+                        + "|" + HOST + "/mangas/"
+                );
+            }
+            // Author
+            manga.setAuthor(getFirstMatchDefault("Auteur : (.+?)</div>", data, context.getString(R.string.nodisponible)));
+            // Genre
+            manga.setGenre(getFirstMatchDefault("Sous-genres : (.+?)<\\/div>", data, context.getString(R.string.nodisponible)));
+            // Summary
+            manga.setSynopsis(getFirstMatchDefault("Synopsis : (.+?)<\\/div>", data, context.getString(R.string.nodisponible)));
+            // Status
+            manga.setFinished(!getFirstMatchDefault("Statut : (.+?)<\\/div>", data, "en cours").contains("en cours"));
+            // Chapters
             Pattern pattern = Pattern.compile("<a href=\"(http[s]*://mangapedia.fr/lel[^\"]+).+?\"nameChapter\">(.+?)<", Pattern.DOTALL);
             Matcher matcher = pattern.matcher(data);
             while (matcher.find()) {
-                manga.addChapter(new Chapter(matcher.group(2).trim().replaceAll("<.*?>", ""),
-                        matcher.group(1)));
+                Chapter chapter = new Chapter(matcher.group(2), matcher.group(1));
+                chapter.addChapterFirst(manga);
             }
         }
     }
@@ -210,27 +281,25 @@ public class Mangapedia extends ServerBase {
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
-        return chapter.getExtra().split("\\|")[page];
+        if (page < 1) {
+            page = 1;
+        }
+        if (page > chapter.getPages()) {
+            page = chapter.getPages();
+        }
+        String extra = chapter.getExtra();
+        if (extra != null) {
+            return extra.split("\\|")[page];
+        }
+        throw new Exception("Error: no image link for this page");
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
         String data = getNavigatorAndFlushParameters().get(chapter.getPath());
-        Pattern p = Pattern.compile("['|\"](http[s]*://mangapedia.fr/project_code/script/image.php\\?path=.+?)['|\"]", Pattern.DOTALL);
-        Matcher m = p.matcher(data);
-        int i = 0;
-        String images = "";
-        while(m.find()){
-            i++;
-            images = images + "|" + m.group(1);
-        }
-        chapter.setPages(i);
-        chapter.setExtra(images);
-    }
-
-    @Override
-    public boolean hasList() {
-        return false;
+        ArrayList<String> images = getAllMatch("['|\"](http[s]*://mangapedia.fr/project_code/script/image.php\\?path=.+?)['|\"]", data);
+        chapter.setPages(images.size());
+        chapter.setExtra(TextUtils.join("|", images));
     }
 
     @Override

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MyMangaIo.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MyMangaIo.java
@@ -17,128 +17,121 @@ import ar.rulosoft.navegadores.Navigator;
 /**
  * Created by Raul on 04/12/2015.
  */
-public class MyMangaIo extends ServerBase {
+class MyMangaIo extends ServerBase {
 
-    private static final String[] genre = {
-            "Josei", "Seinen", "Shojo", "Shonen"
-    };
+    private static final String HOST = "http://www.mymanga.io/";
 
-    private static final String[] genreV = {
-            "&genre%5B4%5D=1", "&genre%5B2%5D=1", "&genre%5B3%5D=1", "&genre%5B1%5D=1"
-    };
-    private static final String[] type = {
-            "Doujinshi", "Magazine", "Manfra", "Manga", "Manhua", "Manhwa"
-    };
-    private static final String[] typeV = {
-            "&type%5B3%5D=1", "&type%5B5%5D=1", "&type%5B6%5D=1", "&type%5B1%5D=1", "&type%5B4%5D=1", "&type%5B2%5D=1",
-    };
-    private static final String[] statut = {
-            "Abandonné", "En cours", "One shot", "Terminé"
-    };
-    private static final String[] statutV = {
-            "&statut%5B4%5D=1", "&statut%5B3%5D=1", "&statut%5B1%5D=1", "&statut%5B2%5D=1"
-    };
-    private static final String[] subGenre = {
-            "Action", "Adulte", "Arts martiaux", "Aventure", "Comédie", "Drame", "Ecchi",
-            "Fantaisie", "Harem", "Historique", "Horreur", "Lolicon", "Mature", "Mecha",
-            "Mystère", "Pervers", "Psychologique", "Romance", "Science fiction", "Shotacon",
-            "Sports", "Surnaturel", "Tragédie", "Tranche de vie", "Travelo", "Vie scolaire",
-            "Yaoi", "Yuri"
-    };
-    private static final String[] subGenreV = {
-            "&subgenre%5B4%5D=1", "&subgenre%5B5%5D=1", "&subgenre%5B23%5D=1", "&subgenre%5B3%5D=1",
-            "&subgenre%5B10%5D=1", "&subgenre%5B12%5D=1", "&subgenre%5B2%5D=1", "&subgenre%5B20%5D=1",
-            "&subgenre%5B25%5D=1", "&subgenre%5B19%5D=1", "&subgenre%5B6%5D=1", "&subgenre%5B30%5D=1",
-            "&subgenre%5B26%5D=1", "&subgenre%5B15%5D=1", "&subgenre%5B22%5D=1", "&subgenre%5B8%5D=1",
-            "&subgenre%5B13%5D=1", "&subgenre%5B1%5D=1", "&subgenre%5B21%5D=1", "&subgenre%5B29%5D=1",
-            "&subgenre%5B17%5D=1", "&subgenre%5B9%5D=1", "&subgenre%5B18%5D=1", "&subgenre%5B16%5D=1",
-            "&subgenre%5B27%5D=1", "&subgenre%5B11%5D=1", "&subgenre%5B28%5D=1", "&subgenre%5B24%5D=1"
-    };
-    private static String HOST = "http://www.mymanga.io/";
-    private static String[] orden = {
-            "Alphabétique"
+    private static final int[] fltDemographic = {
+            R.string.flt_tag_josei,
+            R.string.flt_tag_seinen,
+            R.string.flt_tag_shoujo,
+            R.string.flt_tag_shounen,
     };
 
-    public MyMangaIo(Context context) {
+    private static final String[] valDemographic = {
+            "&genre%5B4%5D=1",
+            "&genre%5B2%5D=1",
+            "&genre%5B3%5D=1",
+            "&genre%5B1%5D=1",
+    };
+
+    private static final int[] fltType = {
+            R.string.flt_tag_doujinshi,
+            R.string.flt_tag_magazine,
+            R.string.flt_tag_manfra,
+            R.string.flt_tag_manga,
+            R.string.flt_tag_manhua,
+            R.string.flt_tag_manhwa,
+    };
+    private static final String[] valType = {
+            "&type%5B3%5D=1",
+            "&type%5B5%5D=1",
+            "&type%5B6%5D=1",
+            "&type%5B1%5D=1",
+            "&type%5B4%5D=1",
+            "&type%5B2%5D=1",
+    };
+
+    private static final int[] fltStatus = {
+            R.string.flt_status_abandoned, //Abandonné
+            R.string.flt_status_ongoing, //En cours
+            R.string.flt_status_one_shot, //One shot
+            R.string.flt_status_completed, //Terminé
+    };
+    private static final String[] valStatus = {
+            "&statut%5B4%5D=1",
+            "&statut%5B3%5D=1",
+            "&statut%5B1%5D=1",
+            "&statut%5B2%5D=1",
+    };
+
+    private static final int[] fltGenre = {
+            R.string.flt_tag_action, //Action
+            R.string.flt_tag_adult, //Adulte
+            R.string.flt_tag_martial_arts, //Arts martiaux
+            R.string.flt_tag_adventure, //Aventure
+            R.string.flt_tag_comedy, //Comédie
+            R.string.flt_tag_drama, //Drame
+            R.string.flt_tag_ecchi, //Ecchi
+            R.string.flt_tag_fantasy, //Fantaisie
+            R.string.flt_tag_harem, //Harem
+            R.string.flt_tag_historical, //Historique
+            R.string.flt_tag_horror, //Horreur
+            R.string.flt_tag_lolicon, //Lolicon
+            R.string.flt_tag_mature, //Mature
+            R.string.flt_tag_mecha, //Mecha
+            R.string.flt_tag_mystery, //Mystère
+            R.string.flt_tag_perverted, //Pervers
+            R.string.flt_tag_psychological, //Psychologique
+            R.string.flt_tag_romance, //Romance
+            R.string.flt_tag_sci_fi, //Science fiction
+            R.string.flt_tag_shotacon, //Shotacon
+            R.string.flt_tag_sports, //Sports
+            R.string.flt_tag_supernatural, //Surnaturel
+            R.string.flt_tag_tragedy, //Tragédie
+            R.string.flt_tag_slice_of_life, //Tranche de vie
+            R.string.flt_tag_travel, //Travelo
+            R.string.flt_tag_school_life, //Vie scolaire
+            R.string.flt_tag_yaoi, //Yaoi
+            R.string.flt_tag_yuri, //Yuri
+    };
+    private static final String[] valGenre = {
+            "&subgenre%5B4%5D=1",
+            "&subgenre%5B5%5D=1",
+            "&subgenre%5B23%5D=1",
+            "&subgenre%5B3%5D=1",
+            "&subgenre%5B10%5D=1",
+            "&subgenre%5B12%5D=1",
+            "&subgenre%5B2%5D=1",
+            "&subgenre%5B20%5D=1",
+            "&subgenre%5B25%5D=1",
+            "&subgenre%5B19%5D=1",
+            "&subgenre%5B6%5D=1",
+            "&subgenre%5B30%5D=1",
+            "&subgenre%5B26%5D=1",
+            "&subgenre%5B15%5D=1",
+            "&subgenre%5B22%5D=1",
+            "&subgenre%5B8%5D=1",
+            "&subgenre%5B13%5D=1",
+            "&subgenre%5B1%5D=1",
+            "&subgenre%5B21%5D=1",
+            "&subgenre%5B29%5D=1",
+            "&subgenre%5B17%5D=1",
+            "&subgenre%5B9%5D=1",
+            "&subgenre%5B18%5D=1",
+            "&subgenre%5B16%5D=1",
+            "&subgenre%5B27%5D=1",
+            "&subgenre%5B11%5D=1",
+            "&subgenre%5B28%5D=1",
+            "&subgenre%5B24%5D=1",
+    };
+
+    MyMangaIo(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_fr);
-        this.setIcon(R.drawable.mymanga);
-        this.setServerName("MyMangaIo");
-        setServerID(ServerBase.MYMANGAIO);
-    }
-
-    @Override
-    public ArrayList<Manga> getMangas() throws Exception {
-        return getMangasFiltered(getBasicFilter(), 0);
-    }
-
-    @Override
-    public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters().size() == 0 || forceReload) {
-            String data = getNavigatorWithNeededHeader().get(manga.getPath());
-            // Front
-            manga.setImages("http://www.mymanga.io/" + getFirstMatchDefault("<img src=\"(images/mangas_thumb/.+?)\"", data, ""));
-            // Summary
-            manga.setSynopsis(getFirstMatchDefault("Synopsis</h1>\\s+<p>(.+?)</p>", data, defaultSynopsis).replaceAll("<.+?>", ""));
-            // Status
-            manga.setFinished(!data.contains("en cours</a>"));
-            // Author
-            manga.setAuthor(Util.getInstance().fromHtml(getFirstMatchDefault("Auteur\\s*:\\s*(.+?)</tr>", data, "")).toString());
-            // Genre
-            manga.setGenre(Util.getInstance().fromHtml(getFirstMatchDefault("Genre\\s*:\\s*(.+?)</tr>", data, "")).toString());
-            // Chapter
-            Pattern p = Pattern.compile("href=\"([^\"]+)\"[^>]+title=\"Li.+?<span class=\"chapter\">(.+?)<", Pattern.DOTALL);
-            Matcher m = p.matcher(data);
-            while (m.find()) {
-                /*Log.d("MyMIO", "1: " + m.group(1));
-                Log.d("MyMIO", "2: " + m.group(2));*/
-                Chapter mc = new Chapter(m.group(2).trim(), m.group(1));
-                mc.addChapterFirst(manga);
-            }
-        }
-    }
-
-    @Override
-    public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters().isEmpty() || forceReload)
-            loadChapters(manga, forceReload);
-    }
-
-    @Override
-    public String getPagesNumber(Chapter chapter, int page) {
-        if (page > chapter.getPages()) {
-            page = 1;
-        }
-        return chapter.getPath() + page;
-
-    }
-
-    @Override
-    public String getImageFrom(Chapter chapter, int page) throws Exception {
-        String data;
-        data = getNavigatorWithNeededHeader().get(this.getPagesNumber(chapter, page));
-        return getFirstMatch("<img src=\"(.+?)\"", data, "Error: Could not get the link to the image");
-    }
-
-    @Override
-    public void chapterInit(Chapter chapter) throws Exception {
-        String source = getNavigatorWithNeededHeader().get(chapter.getPath());
-        /*Log.d("MYIO", "web: " + chapter.getPath());
-        Log.d("MYIO", "source: " + source);*/
-        String pages = getFirstMatch("<span>sur (\\d+)</span>", source, "Error: Could not get the number of pages"); //(\d+)</option></select></span>
-        chapter.setPages(Integer.parseInt(pages));
-    }
-
-    public ArrayList<Manga> getMangasFromSource(String source) throws Exception {
-        ArrayList<Manga> mangas = new ArrayList<>();
-        Pattern p = Pattern.compile("<a href=\"(mangas/[^\"]+?)\">(.+?)<", Pattern.DOTALL);
-        Matcher m = p.matcher(source);
-        while (m.find()) {
-            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(m.group(2)).toString(), HOST + m.group(1), false);
-            manga.setImages("http://www.mymanga.io/images/mangas_thumb/" + getFirstMatchDefault("mangas/(.+?)/", manga.getPath(), "") + ".jpg");
-            mangas.add(manga);
-        }
-        return mangas;
+        setFlag(R.drawable.flag_fr);
+        setIcon(R.drawable.mymanga);
+        setServerName("MyMangaIo");
+        setServerID(MYMANGAIO);
     }
 
     @Override
@@ -147,34 +140,99 @@ public class MyMangaIo extends ServerBase {
     }
 
     @Override
+    public ArrayList<Manga> getMangas() throws Exception {
+        return getMangasFiltered(getBasicFilter(), 0);
+    }
+
+    @Override
+    public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
+        loadChapters(manga, forceReload);
+    }
+
+    @Override
+    public void loadChapters(Manga manga, boolean forceReload) throws Exception {
+        if (manga.getChapters().isEmpty() || forceReload) {
+            String data = getNavigatorWithNeededHeader().get(manga.getPath());
+            // Cover
+            manga.setImages(HOST + getFirstMatchDefault("<img src=\"(images/mangas_thumb/.+?)\"", data, ""));
+            // Summary
+            manga.setSynopsis(getFirstMatchDefault("Synopsis</h1>\\s+<p><[^>]+>(.+?)</p>", data, context.getString(R.string.nodisponible)));
+            // Status
+            manga.setFinished(!data.contains("en cours</a>"));
+            // Author
+            manga.setAuthor(getFirstMatchDefault("Auteur\\s*:\\s*(.+?)</tr>", data, context.getString(R.string.nodisponible)));
+            // Genre
+            manga.setGenre(getFirstMatchDefault("Sous-Genres\\s*:\\s*(.+?)</tr>", data, context.getString(R.string.nodisponible)));
+            // Chapter
+            Pattern p = Pattern.compile("href=\"([^\"]+)\"[^>]+title=\"Li.+?<span class=\"chapter\">(.+?)<", Pattern.DOTALL);
+            Matcher m = p.matcher(data);
+            while (m.find()) {
+                Chapter mc = new Chapter(m.group(2).trim(), m.group(1));
+                mc.addChapterFirst(manga);
+            }
+        }
+    }
+
+    @Override
+    public String getPagesNumber(Chapter chapter, int page) {
+        if (page < 1) {
+            page = 1;
+        }
+        if (page > chapter.getPages()) {
+            page = chapter.getPages();
+        }
+        return chapter.getPath() + page;
+    }
+
+    @Override
+    public String getImageFrom(Chapter chapter, int page) throws Exception {
+        String data;
+        data = getNavigatorWithNeededHeader().get(getPagesNumber(chapter, page));
+        return getFirstMatch(
+                "<img src=\"(http://lel.mymanga.io/[^\"]+)\"",
+                data, "Error: failed to get the link to the image");
+    }
+
+    @Override
+    public void chapterInit(Chapter chapter) throws Exception {
+        String source = getNavigatorWithNeededHeader().get(chapter.getPath());
+        String pages = getFirstMatch("<span>sur (\\d+)</span>", source, "Error: failed to get the number of pages");
+        chapter.setPages(Integer.parseInt(pages));
+    }
+
+    private ArrayList<Manga> getMangasFromSource(String source) throws Exception {
+        ArrayList<Manga> mangas = new ArrayList<>();
+        Pattern p = Pattern.compile("<a href=\"(mangas/[^\"]+?)\">(.+?)<", Pattern.DOTALL);
+        Matcher m = p.matcher(source);
+        while (m.find()) {
+            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(m.group(2)).toString(), HOST + m.group(1), false);
+            manga.setImages(HOST + "/images/mangas_thumb/" + getFirstMatchDefault("mangas/(.+?)/", manga.getPath(), "") + ".jpg");
+            mangas.add(manga);
+        }
+        return mangas;
+    }
+
+    @Override
     public ArrayList<Manga> search(String term) throws Exception {
-        String web = "http://www.mymanga.io/search?name=" + URLEncoder.encode(term, "UTF-8");
+        String web = HOST + "/search?name=" + URLEncoder.encode(term, "UTF-8");
         String data = getNavigatorWithNeededHeader().get(web);
         return getMangasFromSource(data);
     }
 
-
-    //http://www.mymanga.io/search?name=&author=&illustrator=&parution_span=0&parution=
-    // &type%5B3%5D=0&type%5B5%5D=0&type%5B6%5D=0&type%5B1%5D=0&type%5B4%5D=0&type%5B2%5D=0
-    // &statut%5B4%5D=1&statut%5B3%5D=0&statut%5B1%5D=0&statut%5B2%5D=0
-    // &genre%5B4%5D=0&genre%5B2%5D=1&genre%5B3%5D=0&genre%5B1%5D=0
-    // &subgenre%5B4%5D=0&subgenre%5B5%5D=0&subgenre%5B23%5D=0&subgenre%5B3%5D=0&subgenre%5B10%5D=0&subgenre%5B12%5D=0&subgenre%5B2%5D=0&subgenre%5B20%5D=0&subgenre%5B25%5D=1&subgenre%5B19%5D=0&subgenre%5B6%5D=0&subgenre%5B30%5D=0&subgenre%5B26%5D=0&subgenre%5B15%5D=0&subgenre%5B22%5D=0&subgenre%5B8%5D=0&subgenre%5B13%5D=0&subgenre%5B1%5D=0&subgenre%5B21%5D=0&subgenre%5B29%5D=0&subgenre%5B17%5D=0&subgenre%5B9%5D=0&subgenre%5B18%5D=0&subgenre%5B16%5D=0&subgenre%5B27%5D=0&subgenre%5B11%5D=0&subgenre%5B28%5D=0&subgenre%5B24%5D=0
-    // &chapter_span=0&chapter_count=&last_update=&like_span=0&like=&dislike_span=0&dislike=&search=Rechercher
-
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
-        String web = "http://www.mymanga.io/search?name=&author=&illustrator=&parution_span=0&parution=";
+        String web = HOST + "/search?name=&author=&illustrator=&parution_span=0&parution=";
         for (int i = 0; i < filters[0].length; i++) {
-            web = web + typeV[filters[0][i]];
+            web = web + valDemographic[filters[0][i]];
         }
         for (int i = 0; i < filters[1].length; i++) {
-            web = web + statutV[filters[1][i]];
+            web = web + valStatus[filters[1][i]];
         }
         for (int i = 0; i < filters[2].length; i++) {
-            web = web + genreV[filters[2][i]];
+            web = web + valType[filters[2][i]];
         }
         for (int i = 0; i < filters[3].length; i++) {
-            web = web + subGenreV[filters[3][i]];
+            web = web + valGenre[filters[3][i]];
         }
         Navigator nav = getNavigatorWithNeededHeader();
         web = web + "&chapter_span=0&chapter_count=&last_update=&like_span=0&like=&dislike_span=0&dislike=&search=Rechercher";
@@ -185,17 +243,25 @@ public class MyMangaIo extends ServerBase {
     @Override
     public ServerFilter[] getServerFilters() {
         return new ServerFilter[]{
-                new ServerFilter("Type", type, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Statut", statut, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Genre", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Sous-Genres", subGenre, ServerFilter.FilterType.MULTI)
+                new ServerFilter(
+                        context.getString(R.string.flt_demographic),
+                        buildTranslatedStringArray(fltDemographic), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_status),
+                        buildTranslatedStringArray(fltStatus), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_type),
+                        buildTranslatedStringArray(fltType), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_genre),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI)
         };
     }
 
+    @Override
     public Navigator getNavigatorWithNeededHeader() throws Exception {
         Navigator nav = new Navigator(context);
         nav.addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
         return nav;
     }
-
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/NineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/NineManga.java
@@ -150,7 +150,7 @@ class NineManga extends ServerBase {
         Pattern p = Pattern.compile(PATTERN_MANGA, Pattern.DOTALL);
         Matcher m = p.matcher(data);
         while (m.find()) {
-            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(m.group(2)).toString(), HOST + m.group(1), false);
+            Manga manga = new Manga(getServerID(), m.group(2), HOST + m.group(1), false);
             mangas.add(manga);
         }
         return mangas;
@@ -184,7 +184,7 @@ class NineManga extends ServerBase {
             Pattern p = Pattern.compile(PATTERN_CHAPTER, Pattern.DOTALL);
             Matcher m = p.matcher(data);
             while (m.find()) {
-                Chapter mc = new Chapter(Util.getInstance().fromHtml(m.group(3)).toString().trim(), HOST + m.group(1));
+                Chapter mc = new Chapter(m.group(3), HOST + m.group(1));
                 mc.addChapterFirst(manga);
             }
         }
@@ -278,7 +278,7 @@ class NineManga extends ServerBase {
         Matcher m = pattern.matcher(data);
         ArrayList<Manga> mangas = new ArrayList<>();
         while (m.find()) {
-            Manga manga = new Manga(getServerID(), Util.getInstance().fromHtml(m.group(3)).toString(), HOST + m.group(1), false);
+            Manga manga = new Manga(getServerID(), m.group(3), HOST + m.group(1), false);
             manga.setImages(m.group(2));
             mangas.add(manga);
         }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/NineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/NineManga.java
@@ -28,11 +28,11 @@ class NineManga extends ServerBase {
     private static final String PATTERN_COMPLETED =
             "<a class=\"red\" href=\"/category/completed.html\">";
     private static final String PATTERN_AUTHOR =
-            "<a itemprop=\"author\"[^>]+>(.+?)</a>";
+            "<a itemprop=\"author\"[^>]+>([^<]+)</a>";
     private static final String PATTERN_GENRE =
-            "<li itemprop=\"genre\".+?</b>(.+?)</li>";
+            "<li itemprop=\"genre\".+?</b>(.+?)</a>[^<]*</li>";
     private static final String PATTERN_CHAPTER =
-            "<a class=\"chapter_list_a\" href=\"(/chapter.+?)\" title=\"(.+?)\">(.+?)</a>";
+            "<a class=\"chapter_list_a\" href=\"(/chapter[^<\"]+)\" title=\"([^\"]+)\">([^<]+)</a>";
     private static final String PATTERN_PAGES =
             "\\d+/(\\d+)</option>[\\s]*</select>";
     @SuppressWarnings("WeakerAccess")
@@ -178,8 +178,8 @@ class NineManga extends ServerBase {
                     context.getString(R.string.nodisponible)));
             // genre
             manga.setGenre(Util.getInstance().fromHtml(
-                    getFirstMatchDefault(PATTERN_GENRE, data, context.getString(R.string.nodisponible))
-            ).toString().trim().replace(" ", ", "));
+                    getFirstMatchDefault(PATTERN_GENRE, data, context.getString(R.string.nodisponible)).replace("</a>", "</a>,")
+            ).toString().trim());
             // chapter
             Pattern p = Pattern.compile(PATTERN_CHAPTER, Pattern.DOTALL);
             Matcher m = p.matcher(data);
@@ -209,7 +209,7 @@ class NineManga extends ServerBase {
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
-        if (chapter.getExtra() == null) {
+        if ((chapter.getExtra() == null) || (chapter.getExtra().isEmpty())) {
             setExtra(chapter);
         }
         String[] images = chapter.getExtra().split("\\|");

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/NineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/NineManga.java
@@ -145,7 +145,7 @@ class NineManga extends ServerBase {
     @Override
     public ArrayList<Manga> search(String term) throws Exception {
         ArrayList<Manga> mangas = new ArrayList<>();
-        String data = getNavigatorAndFlushParameters().get(
+        String data = getNavigatorWithNeededHeader().get(
                 HOST + "/search/?wd=" + URLEncoder.encode(term, "UTF-8"));
         Pattern p = Pattern.compile(PATTERN_MANGA, Pattern.DOTALL);
         Matcher m = p.matcher(data);
@@ -164,7 +164,7 @@ class NineManga extends ServerBase {
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
         if (manga.getChapters().isEmpty() || forceReload) {
-            String data = getNavigatorAndFlushParameters().get(manga.getPath() + "?waring=1");
+            String data = getNavigatorWithNeededHeader().get(manga.getPath() + "?waring=1");
 
             // cover image
             manga.setImages(getFirstMatchDefault(PATTERN_COVER, data, ""));
@@ -201,8 +201,7 @@ class NineManga extends ServerBase {
 
         if (page == 1) {
             return chapter.getPath();
-        }
-        else {
+        } else {
             return chapter.getPath().replace(".html", "-" + page + ".html");
         }
     }
@@ -217,7 +216,7 @@ class NineManga extends ServerBase {
     }
 
     private void setExtra(Chapter chapter) throws Exception {
-        String source = getNavigatorAndFlushParameters().get(chapter.getPath().replace(".html", "-" + chapter.getPages() + "-1.html"));
+        String source = getNavigatorWithNeededHeader().get(chapter.getPath().replace(".html", "-" + chapter.getPages() + "-1.html"));
         Pattern p = Pattern.compile(PATTERN_IMAGE, Pattern.DOTALL);
         Matcher m = p.matcher(source);
         String images = "";
@@ -230,7 +229,7 @@ class NineManga extends ServerBase {
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
         String data, pages;
-        data = getNavigatorAndFlushParameters().get(chapter.getPath());
+        data = getNavigatorWithNeededHeader().get(chapter.getPath());
         pages = getFirstMatch(PATTERN_PAGES, data, "Error: failed to get the number of pages");
         chapter.setPages(Integer.parseInt(pages));
     }
@@ -268,12 +267,12 @@ class NineManga extends ServerBase {
             }
         }
         String web;
-        if(filters[0].length < 1 && filters[1].length < 1)
+        if (filters[0].length < 1 && filters[1].length < 1)
             web = HOST + valCategory[filters[3][0]];
         else
             web = HOST + "/search/?name_sel=contain&wd=&author_sel=contain&author=&artist_sel=contain&artist=&category_id=" + includedGenres + "&out_category_id=" + excludedGenres + "&completed_series=" + valStatus[filters[2][0]] + "&type=high&page=" + pageNumber + ".html";
 
-        String data = getNavigatorAndFlushParameters().get(web);
+        String data = getNavigatorWithNeededHeader().get(web);
         Pattern pattern = Pattern.compile(PATTERN_MANGA_SEARCHED, Pattern.DOTALL);
         Matcher m = pattern.matcher(data);
         ArrayList<Manga> mangas = new ArrayList<>();

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/RawSenManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/RawSenManga.java
@@ -12,6 +12,7 @@ import ar.rulosoft.mimanganu.R;
 import ar.rulosoft.mimanganu.componentes.Chapter;
 import ar.rulosoft.mimanganu.componentes.Manga;
 import ar.rulosoft.mimanganu.componentes.ServerFilter;
+import ar.rulosoft.mimanganu.utils.HtmlUnescape;
 import ar.rulosoft.mimanganu.utils.Util;
 
 /**
@@ -19,41 +20,104 @@ import ar.rulosoft.mimanganu.utils.Util;
  */
 class RawSenManga extends ServerBase {
 
-    public static String HOST = "http://raw.senmanga.com/";
+    private static final String HOST = "http://raw.senmanga.com/";
 
-    private static String[] genre = new String[]{
-            "All",
-            "Action", "Adult", "Adventure", "Comedy",
-            "Cooking", "Drama", "Ecchi", "Fantasy",
-            "Gender Bender", "Harem", "Historical", "Horror",
-            "Josei", "Light Novel", "Martial Arts", "Mature",
-            "Music", "Mystery", "Psychological", "Romance",
-            "School Life", "Sci-Fi", "Seinen", "Shoujo",
-            "Shoujo Ai", "Shounen", "Shounen Ai", "Slice of Life",
-            "Smut", "Sports", "Supernatural", "Tragedy",
-            "Webtoons", "Yuri"
+    private static final int[] fltGenre = {
+            R.string.flt_tag_all,
+            R.string.flt_tag_action,
+            R.string.flt_tag_adult,
+            R.string.flt_tag_adventure,
+            R.string.flt_tag_comedy,
+            R.string.flt_tag_cooking,
+            R.string.flt_tag_drama,
+            R.string.flt_tag_ecchi,
+            R.string.flt_tag_fantasy,
+            R.string.flt_tag_gender_bender,
+            R.string.flt_tag_harem,
+            R.string.flt_tag_historical,
+            R.string.flt_tag_horror,
+            R.string.flt_tag_josei,
+            R.string.flt_tag_light_novel,
+            R.string.flt_tag_martial_arts,
+            R.string.flt_tag_mature,
+            R.string.flt_tag_music,
+            R.string.flt_tag_mystery,
+            R.string.flt_tag_psychological,
+            R.string.flt_tag_romance,
+            R.string.flt_tag_school_life,
+            R.string.flt_tag_sci_fi,
+            R.string.flt_tag_seinen,
+            R.string.flt_tag_shoujo,
+            R.string.flt_tag_shoujo_ai,
+            R.string.flt_tag_shounen,
+            R.string.flt_tag_shounen_ai,
+            R.string.flt_tag_slice_of_life,
+            R.string.flt_tag_smut,
+            R.string.flt_tag_sports,
+            R.string.flt_tag_supernatural,
+            R.string.flt_tag_tragedy,
+            R.string.flt_tag_webtoon,
+            R.string.flt_tag_yuri
     };
-    private static String[] genreV = new String[]{
+    private static final String[] valGenre = {
             "Manga/",
-            "directory/category/Action/", "directory/category/Adult/", "directory/category/Adventure/", "directory/category/Comedy/",
-            "directory/category/Cooking/", "directory/category/Drama/", "directory/category/Ecchi/", "directory/category/Fantasy/",
-            "directory/category/Gender-Bender/", "directory/category/Harem/", "directory/category/Historical/", "directory/category/Horror/",
-            "directory/category/Josei/", "directory/category/Light_Novel/", "directory/category/Martial_Arts/", "directory/category/Mature/",
-            "directory/category/Music/", "directory/category/Mystery/", "directory/category/Psychological/", "directory/category/Romance/",
-            "directory/category/School_Life/", "directory/category/Sci-Fi/", "directory/category/Seinen/", "directory/category/Shoujo/",
-            "directory/category/Shoujo-Ai/", "directory/category/Shounen/", "directory/category/Shounen-Ai/", "directory/category/Slice_of_Life/",
-            "directory/category/Smut/", "directory/category/Sports/", "directory/category/Supernatural/", "directory/category/Tragedy/",
-            "directory/category/Webtoons/", "directory/category/Yuri/"
+            "directory/category/Action/",
+            "directory/category/Adult/",
+            "directory/category/Adventure/",
+            "directory/category/Comedy/",
+            "directory/category/Cooking/",
+            "directory/category/Drama/",
+            "directory/category/Ecchi/",
+            "directory/category/Fantasy/",
+            "directory/category/Gender-Bender/",
+            "directory/category/Harem/",
+            "directory/category/Historical/",
+            "directory/category/Horror/",
+            "directory/category/Josei/",
+            "directory/category/Light_Novel/",
+            "directory/category/Martial_Arts/",
+            "directory/category/Mature/",
+            "directory/category/Music/",
+            "directory/category/Mystery/",
+            "directory/category/Psychological/",
+            "directory/category/Romance/",
+            "directory/category/School_Life/",
+            "directory/category/Sci-Fi/",
+            "directory/category/Seinen/",
+            "directory/category/Shoujo/",
+            "directory/category/Shoujo-Ai/",
+            "directory/category/Shounen/",
+            "directory/category/Shounen-Ai/",
+            "directory/category/Slice_of_Life/",
+            "directory/category/Smut/",
+            "directory/category/Sports/",
+            "directory/category/Supernatural/",
+            "directory/category/Tragedy/",
+            "directory/category/Webtoons/",
+            "directory/category/Yuri/"
     };
-    private static String[] order = {"Most Popular", "Rating", "Title"};
-    private static String[] orderV = {"Manga/?order=popular", "Manga/?order=rating", "Manga/?order=title"};
+    private static final int[] fltOrder = {
+            R.string.flt_order_views,
+            R.string.flt_order_rating,
+            R.string.flt_order_alpha,
+    };
+    private static final String[] valOrder = {
+            "Manga/?order=popular",
+            "Manga/?order=rating",
+            "Manga/?order=title"
+    };
 
     RawSenManga(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_raw);
-        this.setIcon(R.drawable.senmanga);
-        this.setServerName("SenManga");
-        setServerID(ServerBase.RAWSENMANGA);
+        setFlag(R.drawable.flag_raw);
+        setIcon(R.drawable.senmanga);
+        setServerName("SenManga");
+        setServerID(RAWSENMANGA);
+    }
+
+    @Override
+    public boolean hasList() {
+        return true;
     }
 
     @Override
@@ -63,7 +127,7 @@ class RawSenManga extends ServerBase {
         Pattern p = Pattern.compile("\\d</td><td><a href=\"([^\"]+)\"\\s*>([^<]+)", Pattern.DOTALL);
         Matcher m = p.matcher(data);
         while (m.find()) {
-            Manga manga = new Manga(getServerID(), m.group(2),HOST + m.group(1), false);
+            Manga manga = new Manga(getServerID(), HtmlUnescape.Unescape(m.group(2)), HOST + m.group(1), false);
             mangas.add(manga);
         }
         return mangas;
@@ -71,13 +135,13 @@ class RawSenManga extends ServerBase {
 
     @Override
     public ArrayList<Manga> search(String term) throws Exception {
-        String web = HOST + "Search.php?q=" + URLEncoder.encode(term,"UTF-8");
+        String web = HOST + "Search.php?q=" + URLEncoder.encode(term, "UTF-8");
         String data = getNavigatorAndFlushParameters().get(web);
         Pattern p = Pattern.compile("<div class='search-results'>.+?<a href='(.+?)' title='(.+?)'", Pattern.DOTALL);
         Matcher m = p.matcher(data);
         ArrayList<Manga> mangas = new ArrayList<>();
-        while (m.find()){
-            Manga manga = new Manga(getServerID(),m.group(2),HOST + m.group(1),false);
+        while (m.find()) {
+            Manga manga = new Manga(getServerID(), HtmlUnescape.Unescape(m.group(2)), HOST + m.group(1), false);
             mangas.add(manga);
         }
         return mangas;
@@ -85,7 +149,7 @@ class RawSenManga extends ServerBase {
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters().size() == 0 || forceReload) {
+        if (manga.getChapters().isEmpty() || forceReload) {
             String data = getNavigatorAndFlushParameters().get(manga.getPath());
             String data2 = getFirstMatchDefault("<div class=\"series_desc\">(.+?)<\\/div>", data, "");
             manga.setSynopsis(Util.getInstance().fromHtml(getFirstMatchDefault("<div itemprop=\"description\">(.+?)<", data2, defaultSynopsis)).toString());
@@ -96,7 +160,7 @@ class RawSenManga extends ServerBase {
             Pattern p = Pattern.compile("<td><a href=\"(/.+?)\" title=\"(.+?)\"", Pattern.DOTALL);
             Matcher m = p.matcher(data);
             while (m.find()) {
-                Chapter mc = new Chapter(m.group(2).trim(), HOST + m.group(1));
+                Chapter mc = new Chapter(HtmlUnescape.Unescape(m.group(2).trim()), HOST + m.group(1));
                 mc.addChapterFirst(manga);
             }
         }
@@ -104,8 +168,7 @@ class RawSenManga extends ServerBase {
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters().isEmpty() || forceReload)
-            loadChapters(manga, forceReload);
+        loadChapters(manga, forceReload);
     }
 
 
@@ -118,7 +181,7 @@ class RawSenManga extends ServerBase {
     public String getImageFrom(Chapter chapter, int page) throws Exception {
         if (chapter.getExtra() == null) {
             String data = getNavigatorAndFlushParameters().get(chapter.getPath());
-            chapter.setExtra(getFirstMatchDefault("<img src=\".(vi.+?/)[^/]+?\"", data, "can't get image base"));
+            chapter.setExtra(getFirstMatchDefault("<img src=\".(vi.+?/)[^/]+?\"", data, "Error: failed to locate page image link"));
         }
         return HOST + chapter.getExtra() + page;
     }
@@ -126,9 +189,9 @@ class RawSenManga extends ServerBase {
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
         String data = getNavigatorAndFlushParameters().get(chapter.getPath());
-        String number = getFirstMatchDefault("</select> of (\\d+)", data, "Can't retrieve page quantity");
+        String number = getFirstMatchDefault("</select> of (\\d+)", data, "Error: failed to get the number of pages");
         chapter.setPages(Integer.parseInt(number));
-        chapter.setExtra(getFirstMatchDefault("<img src=\".(vi.+?/)[^/]+?\"", data, "can't get image base"));
+        chapter.setExtra(getFirstMatchDefault("<img src=\".(vi.+?/)[^/]+?\"", data, "Error: failed to locate page image link"));
     }
 
     @NonNull
@@ -136,8 +199,8 @@ class RawSenManga extends ServerBase {
         Pattern p = Pattern.compile("<div class=\"cover\"><a href=\"/(.+?)\" title=\"(.+?)\"><img src=\"/(.+?)\"", Pattern.DOTALL);
         Matcher m = p.matcher(source);
         ArrayList<Manga> mangas = new ArrayList<>();
-        while (m.find()){
-            Manga manga = new Manga(getServerID(),m.group(2),HOST + m.group(1),false);
+        while (m.find()) {
+            Manga manga = new Manga(getServerID(), HtmlUnescape.Unescape(m.group(2)), HOST + m.group(1), false);
             manga.setImages(HOST + m.group(3));
             mangas.add(manga);
         }
@@ -146,23 +209,23 @@ class RawSenManga extends ServerBase {
 
     @Override
     public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{new ServerFilter("Genre", genre, ServerFilter.FilterType.SINGLE),
-                new ServerFilter("Order", order, ServerFilter.FilterType.SINGLE)
+        return new ServerFilter[]{
+                new ServerFilter(
+                        context.getString(R.string.flt_genre),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.SINGLE),
+                new ServerFilter(
+                        context.getString(R.string.flt_order),
+                        buildTranslatedStringArray(fltOrder), ServerFilter.FilterType.SINGLE)
         };
     }
 
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
-        String web = HOST + genreV[filters[0][0]] + "?page=" + pageNumber;
-        if (genre[filters[0][0]].equals("All"))
-            web = HOST + orderV[filters[1][0]] + "&page=" + pageNumber;
+        String web = HOST + valGenre[filters[0][0]] + "?page=" + pageNumber;
+        if (fltGenre[filters[0][0]] == R.string.flt_tag_all) {
+            web = HOST + valOrder[filters[1][0]] + "&page=" + pageNumber;
+        }
         String source = getNavigatorAndFlushParameters().get(web);
         return getMangasFromSource(source);
     }
-
-    @Override
-    public boolean hasList() {
-        return true;
-    }
-
 }

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ReadMangaToday.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ReadMangaToday.java
@@ -1,6 +1,7 @@
 package ar.rulosoft.mimanganu.servers;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import java.util.ArrayList;
 import java.util.regex.Matcher;
@@ -16,53 +17,95 @@ import ar.rulosoft.mimanganu.utils.Util;
  * Created by xtj-9182 on 01.12.2016.
  */
 class ReadMangaToday extends ServerBase {
-    private static String HOST = "http://www.readmanga.today";
-    private static String[] genre = new String[]{
-            "All",
-            "Action",
-            "Adventure",
-            "Comedy",
-            "Doujinshi",
-            "Drama",
-            "Ecchi",
-            "Fantasy",
-            "Gender Bender",
-            "Harem",
-            "Historical",
-            "Horror",
-            "Josei",
-            "Lolicon",
-            "Martial Arts",
-            "Mature",
-            "Mecha",
-            "Mystery",
-            "One shot",
-            "Psychological",
-            "Romance",
-            "School Life",
-            "Sci-fi",
-            "Seinen",
-            "Shotacon",
-            "Shoujo",
-            "Shoujo Ai",
-            "Shounen",
-            "Shounen Ai",
-            "Slice of Life",
-            "Smut",
-            "Sports",
-            "Supernatural",
-            "Tragedy",
-            "Yaoi",
-            "Yuri"
+    private static final String HOST = "http://www.readmanga.today";
+    private static final int[] fltGenre = {
+            R.string.flt_tag_all,
+            R.string.flt_tag_action,
+            R.string.flt_tag_adventure,
+            R.string.flt_tag_comedy,
+            R.string.flt_tag_doujinshi,
+            R.string.flt_tag_drama,
+            R.string.flt_tag_ecchi,
+            R.string.flt_tag_fantasy,
+            R.string.flt_tag_gender_bender,
+            R.string.flt_tag_harem,
+            R.string.flt_tag_historical,
+            R.string.flt_tag_horror,
+            R.string.flt_tag_josei,
+            R.string.flt_tag_lolicon,
+            R.string.flt_tag_martial_arts,
+            R.string.flt_tag_mature,
+            R.string.flt_tag_mecha,
+            R.string.flt_tag_mystery,
+            R.string.flt_tag_one_shot,
+            R.string.flt_tag_psychological,
+            R.string.flt_tag_romance,
+            R.string.flt_tag_school_life,
+            R.string.flt_tag_sci_fi,
+            R.string.flt_tag_seinen,
+            R.string.flt_tag_shotacon,
+            R.string.flt_tag_shoujo,
+            R.string.flt_tag_shoujo_ai,
+            R.string.flt_tag_shounen,
+            R.string.flt_tag_shounen_ai,
+            R.string.flt_tag_slice_of_life,
+            R.string.flt_tag_smut,
+            R.string.flt_tag_sports,
+            R.string.flt_tag_supernatural,
+            R.string.flt_tag_tragedy,
+            R.string.flt_tag_yaoi,
+            R.string.flt_tag_yuri
     };
-    private static String genreVV = "/category/";
+    private static final String[] valGenre = {
+            "/category/",
+            "/category/action/",
+            "/category/adventure/",
+            "/category/comedy/",
+            "/category/doujinshi/",
+            "/category/drama/",
+            "/category/ecchi/",
+            "/category/fantasy/",
+            "/category/gender-bender/",
+            "/category/harem/",
+            "/category/historical/",
+            "/category/horror/",
+            "/category/josei/",
+            "/category/lolicon/",
+            "/category/martial-arts/",
+            "/category/mature/",
+            "/category/mecha/",
+            "/category/mystery/",
+            "/category/one-shot/",
+            "/category/psychological/",
+            "/category/romance/",
+            "/category/school-life/",
+            "/category/sci-fi/",
+            "/category/seinen/",
+            "/category/shotacon/",
+            "/category/shoujo/",
+            "/category/shoujo-ai/",
+            "/category/shounen/",
+            "/category/shounen-ai/",
+            "/category/slice-of-life/",
+            "/category/smut/",
+            "/category/sports/",
+            "/category/supernatural/",
+            "/category/tragedy/",
+            "/category/yaoi/",
+            "/category/yuri/"
+    };
 
     ReadMangaToday(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_en);
-        this.setIcon(R.drawable.readmangatoday);
-        this.setServerName("ReadMangaToday");
-        setServerID(ServerBase.READMANGATODAY);
+        setFlag(R.drawable.flag_en);
+        setIcon(R.drawable.readmangatoday);
+        setServerName("ReadMangaToday");
+        setServerID(READMANGATODAY);
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
     }
 
     @Override
@@ -71,32 +114,29 @@ class ReadMangaToday extends ServerBase {
     }
 
     @Override
-    public ArrayList<Manga> search(String search) throws Exception {
+    public ArrayList<Manga> search(String term) throws Exception {
         ArrayList<Manga> mangas = new ArrayList<>();
-        String web = "http://www.readmanga.today/manga-list/";
-        if (Character.isLetter(search.charAt(0)))
-            web = web + search.toLowerCase().charAt(0);
+        String web = HOST + "/manga-list/" + term.toLowerCase().charAt(0);
         int count = -1;
+        // starting with 't', as this is a common prefix in English
         String[] alphabet = {"t", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "v", "w", "x", "y", "z"};
         while (mangas.isEmpty()) {
-            //Log.d("RMT", "web: " + web);
+            // if the Manga was not found (yet) search through the alphabet
             String source = getNavigatorAndFlushParameters().get(web);
             Pattern pattern = Pattern.compile("<a href=\"(http://www\\.readmanga\\.today/[^\"]+?)\">(.+?)</a>", Pattern.DOTALL);
             Matcher matcher = pattern.matcher(source);
             while (matcher.find()) {
-                if (matcher.group(2).toLowerCase().contains(search.toLowerCase())) {
-                    /*Log.d("RMT", "1: " + matcher.group(1));
-                    Log.d("RMT", "2: " + matcher.group(2));*/
+                if (matcher.group(2).toLowerCase().contains(term.toLowerCase())) {
                     Manga manga = new Manga(getServerID(), matcher.group(2), matcher.group(1), false);
                     mangas.add(manga);
                 }
             }
-            if (count == alphabet.length)
+            if (count == alphabet.length) {
                 break;
-            if (count == -1)
-                web = "http://www.readmanga.today/manga-list/";
-            else {
-                web = "http://www.readmanga.today/manga-list/";
+            }
+
+            web = HOST + "/manga-list/";
+            if (count != -1) {
                 web = web + alphabet[count];
             }
             count++;
@@ -106,67 +146,67 @@ class ReadMangaToday extends ServerBase {
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters() == null || manga.getChapters().size() == 0 || forceReload)
-            loadMangaInformation(manga, forceReload);
+        loadMangaInformation(manga, forceReload);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
-        String source = getNavigatorAndFlushParameters().getAndReturnResponseCodeOnFailure(manga.getPath());
-        if (source.equals("400")) {
-            // ReadMangaToday returns 400 Bad Request sometimes
-            // deleting it's cookies will usually get rid of the error
-            Util.getInstance().removeSpecificCookies(context, HOST);
-        }
+        if (manga.getChapters().isEmpty() || forceReload) {
+            String source = getNavigatorAndFlushParameters().getAndReturnResponseCodeOnFailure(manga.getPath());
+            if (source.equals("400")) {
+                // ReadMangaToday returns 400 Bad Request sometimes
+                // deleting it's cookies will usually get rid of the error
+                Util.getInstance().removeSpecificCookies(context, HOST);
+                source = getNavigatorAndFlushParameters().get(manga.getPath());
+            }
 
-        // Cover
-        if (manga.getImages() == null || manga.getImages().isEmpty() || manga.getImages().contains("thumb")) {
-            String img = getFirstMatchDefault("<div class=\"col-md-3\">.+?<img src=\"(.+?)\" alt=", source, "");
-            manga.setImages(img);
-        }
+            // Cover
+            if (manga.getImages() == null || manga.getImages().isEmpty() || manga.getImages().contains("thumb")) {
+                String img = getFirstMatchDefault("<div class=\"col-md-3\">.+?<img src=\"(.+?)\" alt=", source, "");
+                manga.setImages(img);
+            }
 
-        // Summary
-        String summary = getFirstMatchDefault("<li class=\"list-group-item movie-detail\">(.+?)</li>", source, "");
-        manga.setSynopsis(Util.getInstance().fromHtml(summary.trim()).toString());
+            // Summary
+            String summary = getFirstMatchDefault("<li class=\"list-group-item movie-detail\">(.+?)</li>", source, context.getString(R.string.nodisponible));
+            manga.setSynopsis(summary);
 
-        // Status
-        boolean status = !getFirstMatchDefault("<dt>Status:</dt>.+?<dd>(.+?)</dd>", source, "").contains("Ongoing");
-        manga.setFinished(status);
+            // Status
+            manga.setFinished(!source.contains("<dd>Ongoing</dd>"));
 
-        // Author
-        String author = "";
-        //String author = getFirstMatchDefault("<li class=\"director\">.+?<li><a href=\".+?\">(.+?)</a>", source, "");
-        Pattern p1 = Pattern.compile("<li><a href=\"http://www\\.readmanga\\.today/people/[^\"]+?\">([^\"]+?)</a>", Pattern.DOTALL);
-        Matcher matcher1 = p1.matcher(source);
-        while (matcher1.find()) {
-            //Log.d("RMT", "(1): " + matcher1.group(1));
-            if (!author.equals(matcher1.group(1) + ", ")) {
-                author += matcher1.group(1);
-                author += ", ";
+            // Author (can be multi-part)
+            String author = "";
+            //String author = getFirstMatchDefault("<li class=\"director\">.+?<li><a href=\".+?\">(.+?)</a>", source, "");
+            Pattern p = Pattern.compile("<li><a href=\"http://www\\.readmanga\\.today/people/[^\"]+?\">([^\"]+?)</a>", Pattern.DOTALL);
+            Matcher matcher = p.matcher(source);
+            while (matcher.find()) {
+                if (!author.equals(matcher.group(1) + ", ")) {
+                    author += matcher.group(1);
+                    author += ", ";
+                }
+            }
+            if (!author.isEmpty()) {
+                manga.setAuthor(author.substring(0, author.length() - 2));
+            }
+            else {
+                manga.setAuthor(context.getString(R.string.nodisponible));
+            }
+
+            // Genre
+            String genre = getFirstMatchDefault("<dt>Categories:</dt>.+?<dd>(.+?)</dd>", source, context.getString(R.string.nodisponible))
+                    .replaceAll("</a>", ",");
+            if (genre.endsWith(",")) {
+                genre = genre.substring(0, genre.length() - 1);
+            }
+            manga.setGenre(genre);
+
+            // Chapters
+            p = Pattern.compile("<li>[\\s]*<a href=\"([^\"]+?)\">[\\s]*<span class=\"val\"><span class=\"icon-arrow-.\"></span>(.+?)</span>", Pattern.DOTALL);
+            matcher = p.matcher(source);
+            while (matcher.find()) {
+                Chapter chapter = new Chapter(matcher.group(2), matcher.group(1));
+                chapter.addChapterFirst(manga);
             }
         }
-        if (author.endsWith(", "))
-            author = author.substring(0, author.length() - 2);
-        manga.setAuthor(author);
-
-        // Genre
-        String genre = Util.getInstance().fromHtml(getFirstMatchDefault("<dt>Categories:</dt>.+?<dd>(.+?)</dd>", source, "").replaceAll("</a>", ",</a>")).toString().trim();
-        //Log.d("RMT", "g: " + genre);
-        if (genre.endsWith(","))
-            genre = genre.substring(0, genre.length() - 1);
-        manga.setGenre(genre);
-
-        // Chapters
-        //<li>.+?<a href="(.+?)">.+?<span class="val"><span class="icon-arrow-2"></span>(.+?)</span>
-        Pattern p = Pattern.compile("<li>[\\s]*<a href=\"([^\"]+?)\">[\\s]*<span class=\"val\"><span class=\"icon-arrow-.\"></span>(.+?)</span>", Pattern.DOTALL);
-        Matcher matcher = p.matcher(source);
-        ArrayList<Chapter> chapters = new ArrayList<>();
-        while (matcher.find()) {
-            /*Log.d("RMT", "(2): " + matcher.group(2).trim());
-            Log.d("RMT", "(1): " + matcher.group(1));*/
-            chapters.add(0, new Chapter(matcher.group(2).trim(), matcher.group(1)));
-        }
-        manga.setChapters(chapters);
     }
 
     @Override
@@ -176,83 +216,78 @@ class ReadMangaToday extends ServerBase {
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
-        if (chapter.getExtra() == null)
-            setExtra(chapter);
-        String[] images = chapter.getExtra().split("\\|");
-        return images[page];
+        String extra = chapter.getExtra();
+        if (extra == null) {
+            extra = setExtra(chapter);
+        }
+        return extra.split("\\|")[page];
     }
 
-    private void setExtra(Chapter chapter) throws Exception {
+    private String setExtra(Chapter chapter) throws Exception {
         String source = getNavigatorAndFlushParameters().getAndReturnResponseCodeOnFailure(chapter.getPath() + "/all-pages");
         if (source.equals("400")) {
+            // ReadMangaToday returns 400 Bad Request sometimes
+            // deleting it's cookies will usually get rid of the error
             Util.getInstance().removeSpecificCookies(context, HOST);
+            source = getNavigatorAndFlushParameters().get(chapter.getPath() + "/all-pages");
         }
-        //Log.d("RMT", "s: " + source);
-        Pattern p = Pattern.compile("<img src=\"([^\"]+)\" class=\"img-responsive-2\">", Pattern.DOTALL);
-        Matcher matcher = p.matcher(source);
-        String images = "";
-        while (matcher.find()) {
-            //Log.d("RMT","(1): "+matcher.group(1));
-            images = images + "|" + matcher.group(1);
-        }
-        chapter.setExtra(images);
+        chapter.setExtra(TextUtils.join("|", getAllMatch("<img src=\"([^\"]+)\" class=\"img-responsive-2\">", source)));
+        return chapter.getExtra();
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
         String source = getNavigatorAndFlushParameters().getAndReturnResponseCodeOnFailure(chapter.getPath());
         if (source.equals("400")) {
+            // ReadMangaToday returns 400 Bad Request sometimes
+            // deleting it's cookies will usually get rid of the error
             Util.getInstance().removeSpecificCookies(context, HOST);
+            source = getNavigatorAndFlushParameters().get(chapter.getPath());
         }
-        //Log.d("RMT","p: "+chapter.getPath());
         String pageNumber = getFirstMatchDefault("\">(\\d+)</option>[\\s]*</select>", source,
-                "failed to get the number of pages");
-        //Log.d("RMT","pa: "+pageNumber);
+                "Error: failed to get the number of pages");
         chapter.setPages(Integer.parseInt(pageNumber));
     }
 
     @Override
     public ServerFilter[] getServerFilters() {
-        return new ServerFilter[]{
-                new ServerFilter("Genre(s)", genre, ServerFilter.FilterType.SINGLE),
+        return new ServerFilter[] {
+                new ServerFilter(
+                        context.getString(R.string.flt_genre),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.SINGLE)
         };
     }
 
     @Override
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
         String web;
-        if (genre[filters[0][0]].equals("All")) {
-            if(pageNumber == 1)
+        if (fltGenre[filters[0][0]] == R.string.flt_tag_all) {
+            if (pageNumber == 1) {
                 web = HOST + "/hot-manga/";
-            else
+            }
+            else {
                 web = HOST + "/hot-manga/" + pageNumber;
+            }
+        } else {
+            web = HOST + valGenre[filters[0][0]] + pageNumber;
         }
-        else
-            web = HOST + genreVV + genre[filters[0][0]].toLowerCase().replaceAll(" ","-") +"/"+ pageNumber;
-        //Log.d("RMT", "web: " + web);
         String source = getNavigatorAndFlushParameters().getAndReturnResponseCodeOnFailure(web);
         if (source.equals("400")) {
+            // ReadMangaToday returns 400 Bad Request sometimes
+            // deleting it's cookies will usually get rid of the error
             Util.getInstance().removeSpecificCookies(context, HOST);
+            source = getNavigatorAndFlushParameters().get(web);
         }
         // regex to generate genre ids: <li>.+?title="All Categories - (.+?)">
         Pattern pattern = Pattern.compile("<div class=\"left\">.+?<a href=\"(.+?)\" title=\"(.+?)\"><img src=\"(.+?)\" alt=\"", Pattern.DOTALL);
         Matcher matcher = pattern.matcher(source);
         ArrayList<Manga> mangas = new ArrayList<>();
         while (matcher.find()) {
-            /*Log.d("RMT","(2): "+matcher.group(2));
-            Log.d("RMT","(1): "+matcher.group(1));
-            Log.d("RMT","(3): "+matcher.group(3));*/
             Manga m = new Manga(getServerID(), matcher.group(2), matcher.group(1), false);
-            //Log.d("RMT","img: "+matcher.group(3).replace("thumb/",""));
-            m.setImages(matcher.group(3).replace("thumb/",""));
+            m.setImages(matcher.group(3).replace("thumb/", ""));
             mangas.add(m);
         }
+        hasMore = !mangas.isEmpty();
         return mangas;
     }
-
-    @Override
-    public boolean hasList() {
-        return false;
-    }
 }
-

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/RuNineManga.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/RuNineManga.java
@@ -13,7 +13,7 @@ class RuNineManga extends NineManga {
     private static final String PATTERN_COVER =
             "<img itemprop=\"image\".+?src=\"(.+?)\"";
     private static final String PATTERN_IMAGE =
-            "src=\"(http://pic\\.mangarussia\\.com/comics/[^\"]+?)\"";
+            "src=\"(https://img\\.mangarussia\\.com/comics/[^\"]+?)\"";
 
     private static final int[] fltGenre = {
             // assignment was done using Google Translate

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -23,6 +23,128 @@ import ar.rulosoft.navegadores.Navigator;
 
 /**
  * The base class for all online Manga servers supported by this application.
+ *
+ * Any Manga service shall be based off this class. Please follow this guideline when providing a new
+ * server:
+ *
+ * <ul>
+ *     <li>Subclass the new server from <code>ServerBase</code> and implement it
+ *     <li>Add a new unique identifier to <code>ServerBase</code>
+ *     <li>Add the new server to <code>getServer</code>
+ *     <li>Add the new server to <code>getServers</code>
+ * </ul>
+ *
+ * Hints:
+ * <ul>
+ *     <li>optimize your regular expressions to avoid backtracking
+ *     <li>use the provided functionality from <code>ServerBase</code> as often as possible
+ *     <li>use <code>URLEncoder.encode</code>before passing search terms to the server
+ * </ul>
+ *
+ * Test the server implementation for the following use cases:
+ *
+ * <ul>
+ * <li>TC: Open the server list by clicking the '+' inside the circle.
+ * <li>EX: The server is listed by its name and the correct icon and language flag are shown.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Select the server from the list.
+ * <li>EX: The Manga grid is populated (showing covers and names). If the server supports filtering,
+ * the filter button is visible, if no filtering is possible, the button is hidden.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Scroll the list.
+ * <li>EX: New entries on the grid become visible. Verify that items are continuously fetched as you
+ * scroll.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Click the magnifying glass icon to search for a Manga. Search for 'world'.
+ * <li>EX: A non-empty list of search results is presented, all containing the search term. Special
+ * characters are displayed properly (e.g. apostrophes).
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Select a Manga from the list of search results.
+ * <li>EX: All supported fields contain content as expected (cover, author, genre, status, number of
+ * chapters, summary).
+ * </ul>
+ *
+ * Click the back button twice to return to the list.
+ *
+ * <ul>
+ * <li>TC: If the server supports listing, click the list icon.
+ * <li>EX: A non-empty list of manga is presented.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Select a Manga from the list.
+ * <li>EX: All supported fields contain content as expected (cover, author, genre, status, number of
+ * chapters, summary).
+ * </ul>
+ *
+ * Click the back button to return to the list.
+ *
+ * <ul>
+ * <li>TC: Click the magnifying glass icon to search for a Manga. Search for 'world'.
+ * <li>EX: A non-empty list of search results is presented, all containing the search term. Special
+ * characters are displayed properly (e.g. apostrophes).
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Select a Manga from the list of search results.
+ * <li>EX: All supported fields contain content as expected (cover, author, genre, status, number of
+ * chapters, summary).
+ * </ul>
+ *
+ * Click the back button to return to the filtered list.
+ *
+ * <ul>
+ * <li>TC: Open the filter view and change the default selection.
+ * <li>EX: The filtered view displays Manga matching the filter criteria.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Select a Manga from the list of search results.
+ * <li>EX: All supported fields contain content as expected (cover, author, genre, status, number of
+ * chapters, summary).
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Add the Manga to the database.
+ * <li>EX: No error message is displayed.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Return to the home screen and open the Manga which was just added.
+ * <li>EX: All supported fields contain content as expected (cover, author, genre, summary). The
+ * list of chapters is non-empty.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Pull the chapter list down to initiate a Manga update.
+ * <li>EX: All supported fields contain content as expected (cover, author, genre, summary). The
+ * list of chapters is non-empty.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Open a chapter.
+ * <li>EX: The first page is loaded and displayed.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Scroll through the chapter until the end and scroll further to load the next chapter.
+ * <li>EX: The first page of the next chapter is loaded and displayed. The order is as expected.
+ * </ul>
+ *
+ * <ul>
+ * <li>TC: Return to the home screen and remove the Manga.
+ * <li>EX: The Manga is no longer visible on the home screen.
+ * </ul>
+ *
+ * If all of steps work properly - congratulations, you made it. (o.O)/v
  */
 public abstract class ServerBase {
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -724,9 +724,13 @@ public abstract class ServerBase {
     }
 
 	/**
-	 * Returns the type of filtering supported.
+	 * Returns the type of filtered list display supported.
+     *
+     * Determines the type of filtered list displayed. Either Manga can be presented as a nice grid
+     * with covers (<code>FilteredType.VISUAL</code>) or only as a plain textual list
+     * (<code>FilteredType.TEXT</code>).
 	 *
-	 * @return either VISUAL or TEXT
+	 * @return either <code>FilteredType.VISUAL</code> or <code>FilteredType.TEXT</code>
 	 */
     public FilteredType getFilteredType() {
         return FilteredType.VISUAL;

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -24,127 +24,127 @@ import ar.rulosoft.navegadores.Navigator;
 
 /**
  * The base class for all online Manga servers supported by this application.
- *
+ * <p>
  * Any Manga service shall be based off this class. Please follow this guideline when providing a new
  * server:
- *
+ * <p>
  * <ul>
- *     <li>Subclass the new server from <code>ServerBase</code> and implement it
- *     <li>Add a new unique identifier to <code>ServerBase</code>
- *     <li>Add the new server to <code>getServer</code>
- *     <li>Add the new server to <code>getServers</code>
+ * <li>Subclass the new server from <code>ServerBase</code> and implement it
+ * <li>Add a new unique identifier to <code>ServerBase</code>
+ * <li>Add the new server to <code>getServer</code>
+ * <li>Add the new server to <code>getServers</code>
  * </ul>
- *
+ * <p>
  * Hints:
  * <ul>
- *     <li>optimize your regular expressions to avoid backtracking
- *     <li>use the provided functionality from <code>ServerBase</code> as often as possible
- *     <li>use <code>URLEncoder.encode</code>before passing search terms to the server
+ * <li>optimize your regular expressions to avoid backtracking
+ * <li>use the provided functionality from <code>ServerBase</code> as often as possible
+ * <li>use <code>URLEncoder.encode</code>before passing search terms to the server
  * </ul>
- *
+ * <p>
  * Test the server implementation for the following use cases:
- *
+ * <p>
  * <ul>
  * <li>TC: Open the server list by clicking the '+' inside the circle.
  * <li>EX: The server is listed by its name and the correct icon and language flag are shown.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Select the server from the list.
  * <li>EX: The Manga grid is populated (showing covers and names). If the server supports filtering,
  * the filter button is visible, if no filtering is possible, the button is hidden.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Scroll the list.
  * <li>EX: New entries on the grid become visible. Verify that items are continuously fetched as you
  * scroll.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Click the magnifying glass icon to search for a Manga. Search for 'world'.
  * <li>EX: A non-empty list of search results is presented, all containing the search term. Special
  * characters are displayed properly (e.g. apostrophes).
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Select a Manga from the list of search results.
  * <li>EX: All supported fields contain content as expected (cover, author, genre, status, number of
  * chapters, summary).
  * </ul>
- *
+ * <p>
  * Click the back button twice to return to the list.
- *
+ * <p>
  * <ul>
  * <li>TC: If the server supports listing, click the list icon.
  * <li>EX: A non-empty list of manga is presented.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Select a Manga from the list.
  * <li>EX: All supported fields contain content as expected (cover, author, genre, status, number of
  * chapters, summary).
  * </ul>
- *
+ * <p>
  * Click the back button to return to the list.
- *
+ * <p>
  * <ul>
  * <li>TC: Click the magnifying glass icon to search for a Manga. Search for 'world'.
  * <li>EX: A non-empty list of search results is presented, all containing the search term. Special
  * characters are displayed properly (e.g. apostrophes).
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Select a Manga from the list of search results.
  * <li>EX: All supported fields contain content as expected (cover, author, genre, status, number of
  * chapters, summary).
  * </ul>
- *
+ * <p>
  * Click the back button to return to the filtered list.
- *
+ * <p>
  * <ul>
  * <li>TC: Open the filter view and change the default selection.
  * <li>EX: The filtered view displays Manga matching the filter criteria.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Select a Manga from the list of search results.
  * <li>EX: All supported fields contain content as expected (cover, author, genre, status, number of
  * chapters, summary).
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Add the Manga to the database.
  * <li>EX: No error message is displayed.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Return to the home screen and open the Manga which was just added.
  * <li>EX: All supported fields contain content as expected (cover, author, genre, summary). The
  * list of chapters is non-empty.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Pull the chapter list down to initiate a Manga update.
  * <li>EX: All supported fields contain content as expected (cover, author, genre, summary). The
  * list of chapters is non-empty.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Open a chapter.
  * <li>EX: The first page is loaded and displayed.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Scroll through the chapter until the end and scroll further to load the next chapter.
  * <li>EX: The first page of the next chapter is loaded and displayed. The order is as expected.
  * </ul>
- *
+ * <p>
  * <ul>
  * <li>TC: Return to the home screen and remove the Manga.
  * <li>EX: The Manga is no longer visible on the home screen.
  * </ul>
- *
+ * <p>
  * If all of steps work properly - congratulations, you made it. (o.O)/v
  */
 public abstract class ServerBase {
@@ -196,28 +196,29 @@ public abstract class ServerBase {
     private int icon;
     private int flag;
     private int serverID;
+    private static String cookie = "";
 
     @Deprecated
     String defaultSynopsis = "N/A";
 
-	/**
-	 * Construct a new ServerBase object.
-	 *
-	 * @param context the context for this object
-	 */
+    /**
+     * Construct a new ServerBase object.
+     *
+     * @param context the context for this object
+     */
     public ServerBase(Context context) {
         this.context = context;
     }
 
-	/**
-	 * Get a new ServerBase object via the given identifier.
-	 * If the passed identifier is not known, a DeadServer instance is returned. This mechanism can
-	 * also be used for servers which wen out of commission (like EsMangaHere).
-	 *
-	 * @param  id      the identifier of the server
-	 * @param  context the context for this object
-	 * @return         a ServerBase object or a DeadServer object
-	 */
+    /**
+     * Get a new ServerBase object via the given identifier.
+     * If the passed identifier is not known, a DeadServer instance is returned. This mechanism can
+     * also be used for servers which wen out of commission (like EsMangaHere).
+     *
+     * @param id      the identifier of the server
+     * @param context the context for this object
+     * @return a ServerBase object or a DeadServer object
+     */
     public static ServerBase getServer(int id, Context context) {
         ServerBase serverBase;
         switch (id) {
@@ -321,46 +322,45 @@ public abstract class ServerBase {
         return serverBase;
     }
 
-	/**
-	 * Return a clean Navigator instance with old POST parameters flushed.
-	 *
-	 * @return the Navigator object
-	 */
+    /**
+     * Return a clean Navigator instance with old POST parameters flushed.
+     *
+     * @return the Navigator object
+     */
     public static Navigator getNavigatorAndFlushParameters() {
         Navigator.navigator.flushParameter();
         return Navigator.navigator;
     }
 
-	/**
-	 * Returns the first regular expression match on a string, or throws an Exception.
-	 * If the pattern is found in the source string, the first match group is returned. In case no
-	 * match can be done, an Exception is raised with the passed errorMsg string as payload.
-	 *
-	 * @param patron   the regular expression pattern to match
-	 * @param source   the string to check the pattern for
-	 * @param errorMsg the descriptive error message string for the Exception raised if not match
-	 *                 could be found
-	 * @return         the first match group
-	 */
+    /**
+     * Returns the first regular expression match on a string, or throws an Exception.
+     * If the pattern is found in the source string, the first match group is returned. In case no
+     * match can be done, an Exception is raised with the passed errorMsg string as payload.
+     *
+     * @param patron   the regular expression pattern to match
+     * @param source   the string to check the pattern for
+     * @param errorMsg the descriptive error message string for the Exception raised if not match
+     *                 could be found
+     * @return the first match group
+     */
     public static String getFirstMatch(String patron, String source, String errorMsg) throws Exception {
         Pattern p = Pattern.compile(patron, Pattern.DOTALL);
         Matcher m = p.matcher(source);
         if (m.find()) {
             return m.group(1);
-        }
-        else {
+        } else {
             throw new Exception(errorMsg);
         }
     }
 
-	/**
-	 * Returns a list of registered servers.
-	 * Returns an array of all possible server objects (except DeadServer of course) with a given
-	 * context.
-	 *
-	 * @param context the context for this object
-	 * @return        an array containing ServerBase instances - for each registered server
-	 */
+    /**
+     * Returns a list of registered servers.
+     * Returns an array of all possible server objects (except DeadServer of course) with a given
+     * context.
+     *
+     * @param context the context for this object
+     * @return an array containing ServerBase instances - for each registered server
+     */
     public static ServerBase[] getServers(Context context) {
         return (new ServerBase[]{
                 new TuMangaOnline(context),
@@ -398,134 +398,135 @@ public abstract class ServerBase {
     }
 
     /**
-	 * Returns the list of Manga found on the server.
-     *
+     * Returns the list of Manga found on the server.
+     * <p>
      * This function shall only be called if <code>hasList</code> returns <code>true</code>.
-	 *
-	 * @return           an ArrayList of Manga objects or <code>null</code> if unsupported.
-	 * @throws Exception if an error occurred
-	 */
+     *
+     * @return an ArrayList of Manga objects or <code>null</code> if unsupported.
+     * @throws Exception if an error occurred
+     */
     @Nullable
     public abstract ArrayList<Manga> getMangas() throws Exception;
 
-	/**
-	 * Returns a list of Manga filtered by a given search term.
-     *
+    /**
+     * Returns a list of Manga filtered by a given search term.
+     * <p>
      * This function shall only be called if <code>hasSearch</code> returns <code>true</code>.
-	 *
-	 * @param term       a term to search for
-	 * @return           an ArrayList of Manga objects or <code>null</code> if unsupported.
-	 * @throws Exception if an error occurred
-	 */
+     *
+     * @param term a term to search for
+     * @return an ArrayList of Manga objects or <code>null</code> if unsupported.
+     * @throws Exception if an error occurred
+     */
     public abstract ArrayList<Manga> search(String term) throws Exception;
 
     /**
-	 * Load all available chapters for a given Manga.
-	 *
-	 * @param manga       the Manga to find chapters for
-	 * @param forceReload force new retrieval of chapter information
-	 * @throws Exception  if an error occurred
-	 * @see               Chapter
-	 */
+     * Load all available chapters for a given Manga.
+     *
+     * @param manga       the Manga to find chapters for
+     * @param forceReload force new retrieval of chapter information
+     * @throws Exception if an error occurred
+     * @see Chapter
+     */
     public abstract void loadChapters(Manga manga, boolean forceReload) throws Exception;
-	/**
-	 * Load available information for a given Manga.
-	 * Load and add information to a given Manga, like:
-	 * <ul>
-	 * <li>cover image
-	 * <li>summary
-	 * <li>ongoing/finished
-	 * <li>genre
-	 * <li>chapters
-	 * </ul>
-	 *
-	 * @param manga       the Manga to find information for
-	 * @param forceReload force new retrieval of Manga information
-	 * @throws Exception  if an error occurred
-	 * @see               Manga
-	 * @see               Chapter
-	 */
+
+    /**
+     * Load available information for a given Manga.
+     * Load and add information to a given Manga, like:
+     * <ul>
+     * <li>cover image
+     * <li>summary
+     * <li>ongoing/finished
+     * <li>genre
+     * <li>chapters
+     * </ul>
+     *
+     * @param manga       the Manga to find information for
+     * @param forceReload force new retrieval of Manga information
+     * @throws Exception if an error occurred
+     * @see Manga
+     * @see Chapter
+     */
     public abstract void loadMangaInformation(Manga manga, boolean forceReload) throws Exception;
 
     /**
-	 * Returns the URL for the given page in a Chapter.
-	 * Some sanity checking should be done in the override function, like non-negativity and that
-	 * page lies within the available page numbers of the given Chapter.
-	 *
-	 * @param chapter a Chapter object to get the page URL for
-	 * @param page    the page number
-	 * @return        the URL to the given page of the Chapter
-	 */
+     * Returns the URL for the given page in a Chapter.
+     * Some sanity checking should be done in the override function, like non-negativity and that
+     * page lies within the available page numbers of the given Chapter.
+     *
+     * @param chapter a Chapter object to get the page URL for
+     * @param page    the page number
+     * @return the URL to the given page of the Chapter
+     */
     public abstract String getPagesNumber(Chapter chapter, int page);
 
-	/**
-	 * Returns the URL for the image on a given Chapter page.
-	 * Some sanity checking should be done in the override function, like non-negativity and that
-	 * page lies within the available page numbers of the given Chapter.
-	 *
-	 * @param chapter    a Chapter object to get the page image URL for
-	 * @param page       the page number
-	 * @return           the URL to the image on the given page of the Chapter
-	 * @throws Exception if an error occurred
-	 */
+    /**
+     * Returns the URL for the image on a given Chapter page.
+     * Some sanity checking should be done in the override function, like non-negativity and that
+     * page lies within the available page numbers of the given Chapter.
+     *
+     * @param chapter a Chapter object to get the page image URL for
+     * @param page    the page number
+     * @return the URL to the image on the given page of the Chapter
+     * @throws Exception if an error occurred
+     */
     public abstract String getImageFrom(Chapter chapter, int page) throws Exception;
 
-	/**
-	 * Initialise the Chapter information, basically the number of pages.
-	 *
-	 * @param chapter    the Chapter object to do the initialisation for
-	 * @throws Exception if an error occurred
-	 */
+    /**
+     * Initialise the Chapter information, basically the number of pages.
+     *
+     * @param chapter the Chapter object to do the initialisation for
+     * @throws Exception if an error occurred
+     */
     public abstract void chapterInit(Chapter chapter) throws Exception;
 
     /**
-	 * Returns a list of Manga filtered by the given filter set.
-	 * There might be more than one result page, so pageNumber is used to get a certain result page.
-	 * If more information is available, the hasMore variable shall be set to <code>true</code> to
-	 * indicate this condition to the caller in order to fetch the next page.
-     *
+     * Returns a list of Manga filtered by the given filter set.
+     * There might be more than one result page, so pageNumber is used to get a certain result page.
+     * If more information is available, the hasMore variable shall be set to <code>true</code> to
+     * indicate this condition to the caller in order to fetch the next page.
+     * <p>
      * The filter parameter contains the current selection. The first index is given by the order
      * of filters returned by <code>getServerFilters()</code>. The second index indicates the
      * current selection for the criteria given in the first index.
-     *
+     * <p>
      * So if the ordering of the filter criteria is changed, make sure to reflect the change in this
      * function as well.
-	 *
-	 * @param filters    the filter set to use
-	 * @param pageNumber the result page number for a given filter
-	 * @return           a list of Manga matching the filter criteria
-	 * @throws Exception if an error occurred
-	 */
+     *
+     * @param filters    the filter set to use
+     * @param pageNumber the result page number for a given filter
+     * @return a list of Manga matching the filter criteria
+     * @throws Exception if an error occurred
+     */
     public ArrayList<Manga> getMangasFiltered(int[][] filters, int pageNumber) throws Exception {
         return new ArrayList<>();
     }
 
-	/**
-	 * Returns information if the server provides a Manga listing.
+    /**
+     * Returns information if the server provides a Manga listing.
      * If <code>true</code> is returned, getMangas() must be implemented properly.
-	 *
-	 * @return <code>true</code> if the server provides a list of Manga, <code>false</code>
-	 *         otherwise
-	 */
+     *
+     * @return <code>true</code> if the server provides a list of Manga, <code>false</code>
+     * otherwise
+     */
     public abstract boolean hasList();
 
-	/**
-	 * Searches for new chapters for a given Manga.
-	 * Loads information from the database and fetches the current state from the server. Afterwards
-	 * the server information is compared to the local information to check if new chapters are
-	 * available.
-	 *
-	 * A fast check can be triggered to reduce load and compare time by checking only the last 20
-	 * chapters for differences.
-	 *
-	 * All detected changes are also stored in the database.
-	 *
-	 * @param id         the Manga id to check new chapters for
-	 * @param context    the Context object to use for checking
-	 * @param fast       <code>true</code> to perform a fast check (first 20 chapters only)
-	 * @return           the count of new chapters found
-	 * @throws Exception if an error occurred
-	 */
+    /**
+     * Searches for new chapters for a given Manga.
+     * Loads information from the database and fetches the current state from the server. Afterwards
+     * the server information is compared to the local information to check if new chapters are
+     * available.
+     * <p>
+     * A fast check can be triggered to reduce load and compare time by checking only the last 20
+     * chapters for differences.
+     * <p>
+     * All detected changes are also stored in the database.
+     *
+     * @param id      the Manga id to check new chapters for
+     * @param context the Context object to use for checking
+     * @param fast    <code>true</code> to perform a fast check (first 20 chapters only)
+     * @return the count of new chapters found
+     * @throws Exception if an error occurred
+     */
     public int searchForNewChapters(int id, Context context, boolean fast) throws Exception {
         int returnValue;
         Manga mangaDb = Database.getFullManga(context, id);
@@ -605,82 +606,86 @@ public abstract class ServerBase {
         return returnValue;
     }
 
-	/**
-	 * Returns the server icon resource identifier.
-	 *
-	 * @return the server icon resource identifier
-	 */
+    /**
+     * Returns the server icon resource identifier.
+     *
+     * @return the server icon resource identifier
+     */
     public int getIcon() {
         return icon;
     }
-	/**
-	 * Sets the server icon resource identifier.
-	 *
-	 * @param icon the server icon resource identifier to set
-	 */
+
+    /**
+     * Sets the server icon resource identifier.
+     *
+     * @param icon the server icon resource identifier to set
+     */
     public void setIcon(int icon) {
         this.icon = icon;
     }
 
-	/**
-	 * Returns the flag icon resource identifier.
-	 *
-	 * @return the flag icon resource identifier
-	 */
+    /**
+     * Returns the flag icon resource identifier.
+     *
+     * @return the flag icon resource identifier
+     */
     public int getFlag() {
         return flag;
     }
-	/**
-	 * Sets the flag icon resource identifier.
-	 *
-	 * @param flag the flag icon resource identifier to set
-	 */
+
+    /**
+     * Sets the flag icon resource identifier.
+     *
+     * @param flag the flag icon resource identifier to set
+     */
     public void setFlag(int flag) {
         this.flag = flag;
     }
 
-	/**
-	 * Returns the server resource identifier.
-	 *
-	 * @return the server resource identifier
-	 */
+    /**
+     * Returns the server resource identifier.
+     *
+     * @return the server resource identifier
+     */
     public int getServerID() {
         return serverID;
     }
-	/**
-	 * Sets the server identifier.
-	 *
-	 * @param serverID the server identifier to set
-	 */
+
+    /**
+     * Sets the server identifier.
+     *
+     * @param serverID the server identifier to set
+     */
     public void setServerID(int serverID) {
         this.serverID = serverID;
     }
 
-	/**
-	 * Returns the server name.
-	 *
-	 * @return the server name
-	 */
+    /**
+     * Returns the server name.
+     *
+     * @return the server name
+     */
     public String getServerName() {
         return serverName;
     }
-	/**
-	 * Sets the server name.
-	 *
-	 * @param serverName the server name to set
-	 */
+
+    /**
+     * Sets the server name.
+     *
+     * @param serverName the server name to set
+     */
     public void setServerName(String serverName) {
         this.serverName = serverName;
     }
 
-	/**
-	 * Returns a list of matches for a given pattern and string.
-	 *
-	 * @param patron     the pattern to search for
-	 * @param source     the string to search
-	 * @return           a list of matches (may be empty)
-	 * @throws Exception if an error occurred
-	 */
+    /**
+     * Returns a list of matches for a given pattern and string.
+     *
+     * @param patron the pattern to search for
+     * @param source the string to search
+     * @return a list of matches (may be empty)
+     * @throws Exception if an error occurred
+     */
     ArrayList<String> getAllMatch(String patron, String source) throws Exception {
         Pattern p = Pattern.compile(patron, Pattern.DOTALL);
         Matcher m = p.matcher(source);
@@ -691,14 +696,14 @@ public abstract class ServerBase {
         return matches;
     }
 
-	/**
-	 * Returns the first match for a given pattern and string or a default text.
-	 *
-	 * @param patron   the pattern to search for
-	 * @param source   the string to search
-	 * @param mDefault the default string to return in case no match was found
-	 * @return         the first match or the value defined by mDefault
-	 */
+    /**
+     * Returns the first match for a given pattern and string or a default text.
+     *
+     * @param patron   the pattern to search for
+     * @param source   the string to search
+     * @param mDefault the default string to return in case no match was found
+     * @return the first match or the value defined by mDefault
+     */
     public String getFirstMatchDefault(String patron, String source, String mDefault) {
         Pattern p = Pattern.compile(patron, Pattern.DOTALL);
         Matcher m = p.matcher(source);
@@ -709,21 +714,21 @@ public abstract class ServerBase {
         }
     }
 
-	/**
-	 * Returns information if a referrer is needed for image loading.
-	 *
-	 * @return <code>true</code> if a referrer is needed
-	 */
+    /**
+     * Returns information if a referrer is needed for image loading.
+     *
+     * @return <code>true</code> if a referrer is needed
+     */
     public boolean needRefererForImages() {
         return true;
     }
 
-	/**
-	 * Returns information if the server offers filtered navigation.
-	 * If <code>true</code> is returned, <code>getMangasFiltered</code> must be implemented properly.
+    /**
+     * Returns information if the server offers filtered navigation.
+     * If <code>true</code> is returned, <code>getMangasFiltered</code> must be implemented properly.
      *
-	 * @return <code>true</code> if filtered navigation is offered
-	 */
+     * @return <code>true</code> if filtered navigation is offered
+     */
     public boolean hasFilteredNavigation() {
         return true;
     }
@@ -739,32 +744,32 @@ public abstract class ServerBase {
     }
 
     /**
-	 * Returns the type of filtered list display supported.
-     *
+     * Returns the type of filtered list display supported.
+     * <p>
      * Determines the type of filtered list displayed. Either Manga can be presented as a nice grid
      * with covers (<code>FilteredType.VISUAL</code>) or only as a plain textual list
      * (<code>FilteredType.TEXT</code>).
-	 *
-	 * @return either <code>FilteredType.VISUAL</code> or <code>FilteredType.TEXT</code>
-	 */
+     *
+     * @return either <code>FilteredType.VISUAL</code> or <code>FilteredType.TEXT</code>
+     */
     public FilteredType getFilteredType() {
         return FilteredType.VISUAL;
     }
 
-	/**
-	 * Returns the supported server filters for this server.
-	 *
-	 * @return a list of ServerFilter supported by this server
-	 */
+    /**
+     * Returns the supported server filters for this server.
+     *
+     * @return a list of ServerFilter supported by this server
+     */
     public ServerFilter[] getServerFilters() {
         return new ServerFilter[]{};
     }
 
-	/**
-	 * Returns the most basic filter set for this server.
+    /**
+     * Returns the most basic filter set for this server.
      *
      * @return the basic filter for this server
-	 */
+     */
     public int[][] getBasicFilter() {
         ServerFilter[] filters = getServerFilters();
         int[][] result = new int[filters.length][];
@@ -779,33 +784,33 @@ public abstract class ServerBase {
         return result;
     }
 
-	/**
-	 * Returns information the server needs a login.
-	 *
-	 * @return <code>true</code> if a login is needed
-	 */
+    /**
+     * Returns information the server needs a login.
+     *
+     * @return <code>true</code> if a login is needed
+     */
     public boolean needLogin() {
         return false;
     }
 
-	/**
-	 * Returns information if credentials are present.
-	 * Should return <code>true</code> to disable querying credentials.
-	 *
-	 * @return <code>true</code> if credentials are present
-	 */
+    /**
+     * Returns information if credentials are present.
+     * Should return <code>true</code> to disable querying credentials.
+     *
+     * @return <code>true</code> if credentials are present
+     */
     public boolean hasCredentials() {
         return true;
     }
 
-	/**
-	 * Tests if the given login data is working.
-	 *
-	 * @param user the user to log in
-	 * @param passwd the password to use for logging in
-	 * @return <code>true</code> if the login succeeded, <code>false</code> otherwise
-	 * @throws Exception if an error occurred
-	 */
+    /**
+     * Tests if the given login data is working.
+     *
+     * @param user   the user to log in
+     * @param passwd the password to use for logging in
+     * @return <code>true</code> if the login succeeded, <code>false</code> otherwise
+     * @throws Exception if an error occurred
+     */
     public boolean testLogin(String user, String passwd) throws Exception {
         return false;
     }
@@ -824,10 +829,38 @@ public abstract class ServerBase {
         return result;
     }
 
-	/**
-	 * An enumeration for the type of filtering supported.
-	 */
-    public enum FilteredType {VISUAL, TEXT}
+    /**
+     * An enumeration for the type of filtering supported.
+     */
+    public enum FilteredType {
+        VISUAL, TEXT
+    }
+
+    /**
+     * Helper function to generate the Cookie needed by some webpages (like NineManga).
+     */
+    private static void generateNeededCookie() {
+        cookie = "__utmz=128769555." + (System.currentTimeMillis() / 1000) + ".1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none); ";
+    }
+
+    /**
+     * Helper function to get a <code>Navigator</code> instance with additional headers.
+     * Some servers need additional information to be added to the request header in order to work.
+     * This function provides such an object.
+     *
+     * @return a <code>Navigator object with extended headers</code>
+     * @throws Exception if an error occurred
+     */
+    public Navigator getNavigatorWithNeededHeader() throws Exception {
+        if (cookie.isEmpty()) {
+            generateNeededCookie();
+        }
+        Navigator nav = new Navigator(context);
+        nav.addHeader("Accept-Language", "es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3");
+        nav.addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+        nav.addHeader("Cookie", cookie);
+        return nav;
+    }
 
     class CreateGroupByMangaNotificationsTask extends AsyncTask<Void, Integer, Integer> {
         private ArrayList<Chapter> simpleList = new ArrayList<>();

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -191,12 +191,14 @@ public abstract class ServerBase {
     static final int VIEWCOMIC = 1004;
 
     public boolean hasMore = true;
-    protected String defaultSynopsis = "N/A";
     Context context;
     private String serverName;
     private int icon;
     private int flag;
     private int serverID;
+
+    @Deprecated
+    String defaultSynopsis = "N/A";
 
 	/**
 	 * Construct a new ServerBase object.
@@ -405,11 +407,14 @@ public abstract class ServerBase {
 	 */
     @Nullable
     public abstract ArrayList<Manga> getMangas() throws Exception;
+
 	/**
 	 * Returns a list of Manga filtered by a given search term.
+     *
+     * This function shall only be called if <code>hasSearch</code> returns <code>true</code>.
 	 *
 	 * @param term       a term to search for
-	 * @return           an ArrayList of Manga objects
+	 * @return           an ArrayList of Manga objects or <code>null</code> if unsupported.
 	 * @throws Exception if an error occurred
 	 */
     public abstract ArrayList<Manga> search(String term) throws Exception;
@@ -676,7 +681,7 @@ public abstract class ServerBase {
 	 * @return           a list of matches (may be empty)
 	 * @throws Exception if an error occurred
 	 */
-    public ArrayList<String> getAllMatch(String patron, String source) throws Exception {
+    ArrayList<String> getAllMatch(String patron, String source) throws Exception {
         Pattern p = Pattern.compile(patron, Pattern.DOTALL);
         Matcher m = p.matcher(source);
         ArrayList<String> matches = new ArrayList<>();
@@ -715,7 +720,7 @@ public abstract class ServerBase {
 
 	/**
 	 * Returns information if the server offers filtered navigation.
-	 * If <code>true</code> is returned, getMangasFiltered() must be implemented properly.
+	 * If <code>true</code> is returned, <code>getMangasFiltered</code> must be implemented properly.
      *
 	 * @return <code>true</code> if filtered navigation is offered
 	 */
@@ -723,7 +728,17 @@ public abstract class ServerBase {
         return true;
     }
 
-	/**
+    /**
+     * Returns information if the server offers a search functionality.
+     * If <code>true</code> is returned, <code>search</code> must be implemented properly.
+     *
+     * @return <code>true</code> if search feature is offered in the filtered view
+     */
+    public boolean hasSearch() {
+        return true;
+    }
+
+    /**
 	 * Returns the type of filtered list display supported.
      *
      * Determines the type of filtered list displayed. Either Manga can be presented as a nice grid
@@ -801,8 +816,7 @@ public abstract class ServerBase {
      * @param resId an array containing the resource identifiers
      * @return an array of translated strings
      */
-    @SuppressWarnings("WeakerAccess")
-    protected String[] buildTranslatedStringArray(int[] resId) {
+    String[] buildTranslatedStringArray(int[] resId) {
         String[] result = new String[resId.length];
         for (int i = 0; i < resId.length; i++) {
             result[i] = context.getString(resId[i]);

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -3,6 +3,7 @@ package ar.rulosoft.mimanganu.servers;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
+import android.support.annotation.Nullable;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -396,10 +397,13 @@ public abstract class ServerBase {
 
     /**
 	 * Returns the list of Manga found on the server.
+     *
+     * This function shall only be called if <code>hasList</code> returns <code>true</code>.
 	 *
-	 * @return           an ArrayList of Manga objects
+	 * @return           an ArrayList of Manga objects or <code>null</code> if unsupported.
 	 * @throws Exception if an error occurred
 	 */
+    @Nullable
     public abstract ArrayList<Manga> getMangas() throws Exception;
 	/**
 	 * Returns a list of Manga filtered by a given search term.

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -431,13 +431,13 @@ public abstract class ServerBase {
 
         boolean changes = false;
         if (!mangaDb.getAuthor().equals(manga.getAuthor()) &&
-                manga.getAuthor().length() > 2) {
+                manga.getAuthor() != null && manga.getAuthor().length() > 2) {
             mangaDb.setAuthor(manga.getAuthor());
             changes = true;
         }
 
-        if (!mangaDb.getImages().equals(manga.getImages()) &&
-                manga.getImages().length() > 2) {
+        if (mangaDb.getImages() != null && !mangaDb.getImages().equals(manga.getImages()) &&
+                manga.getImages() != null && manga.getImages().length() > 2) {
             mangaDb.setImages(manga.getImages());
             changes = true;
         }
@@ -462,7 +462,7 @@ public abstract class ServerBase {
             DateFormat dateFormat = new SimpleDateFormat("dd.MM.yyyy", Locale.getDefault());
             Date date = new Date();
             String lastUpdate = dateFormat.format(date);
-            if (!mangaDb.getLastUpdate().equals(lastUpdate)) {
+            if (mangaDb.getLastUpdate() != null && !mangaDb.getLastUpdate().equals(lastUpdate)) {
                 mangaDb.setLastUpdate(lastUpdate);
                 changes = true;
             }
@@ -671,6 +671,7 @@ public abstract class ServerBase {
      * @param resId an array containing the resource identifiers
      * @return an array of translated strings
      */
+    @SuppressWarnings("WeakerAccess")
     protected String[] buildTranslatedStringArray(int[] resId) {
         String[] result = new String[resId.length];
         for (int i = 0; i < resId.length; i++) {

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/Taadd.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/Taadd.java
@@ -11,7 +11,6 @@ import ar.rulosoft.mimanganu.R;
 import ar.rulosoft.mimanganu.componentes.Chapter;
 import ar.rulosoft.mimanganu.componentes.Manga;
 import ar.rulosoft.mimanganu.componentes.ServerFilter;
-import ar.rulosoft.mimanganu.utils.Util;
 import ar.rulosoft.navegadores.Navigator;
 
 /**
@@ -20,40 +19,159 @@ import ar.rulosoft.navegadores.Navigator;
 class Taadd extends ServerBase {
     private static String HOST = "http://www.taadd.com";
 
-    private static String[] genre = new String[]{
-            "4-Koma", "Action", "Adult", "Adventure", "Anime", "Award Winning",
-            "Bara", "Comedy", "Cooking", "Demons", "Doujinshi", "Drama", "Ecchi", "Fantasy", "Gender Bender",
-            "Harem", "Historical", "Horror", "Josei", "Live Action", "Magic", "Manhua", "Manhwa",
-            "Martial Arts", "Matsumoto...", "Mature", "Mecha", "Medical", "Military", "Music",
-            "Mystery", "N/A", "None", "One Shot", "Oneshot", "Psychological", "Reverse Harem",
-            "Romance", "Romance Shoujo", "School Life", "Sci-Fi", "Seinen", "Shoujo", "Shoujo Ai",
-            "Shoujo-Ai", "Shoujoai", "Shounen", "Shounen Ai", "Shounen-Ai", "Shounenai", "Slice Of Life",
-            "Smut", "Sports", "Staff Pick", "Super Power", "Supernatural", "Suspense", "Tragedy",
-            "Vampire", "Webtoon", "Webtoons", "Yaoi", "Yuri", "[No Chapters]"
+    private static final int[] fltGenre = {
+            R.string.flt_tag_4_koma,
+            R.string.flt_tag_action,
+            R.string.flt_tag_adult,
+            R.string.flt_tag_adventure,
+            R.string.flt_tag_anime,
+            R.string.flt_tag_award_winning,
+            R.string.flt_tag_bara,
+            R.string.flt_tag_comedy,
+            R.string.flt_tag_cooking,
+            R.string.flt_tag_daemons,
+            R.string.flt_tag_doujinshi,
+            R.string.flt_tag_drama,
+            R.string.flt_tag_ecchi,
+            R.string.flt_tag_fantasy,
+            R.string.flt_tag_gender_bender,
+            R.string.flt_tag_harem,
+            R.string.flt_tag_historical,
+            R.string.flt_tag_horror,
+            R.string.flt_tag_josei,
+            R.string.flt_tag_live_action,
+            R.string.flt_tag_magic,
+            R.string.flt_tag_manhua,
+            R.string.flt_tag_manhwa,
+            R.string.flt_tag_martial_arts,
+            R.string.flt_tag_matsumoto,
+            R.string.flt_tag_mature,
+            R.string.flt_tag_mecha,
+            R.string.flt_tag_medical,
+            R.string.flt_tag_military,
+            R.string.flt_tag_music,
+            R.string.flt_tag_mystery,
+            R.string.flt_tag_none,
+            R.string.flt_tag_one_shot,
+            R.string.flt_tag_psychological,
+            R.string.flt_tag_reverse_harem,
+            R.string.flt_tag_romance,
+            R.string.flt_tag_school_life,
+            R.string.flt_tag_sci_fi,
+            R.string.flt_tag_seinen,
+            R.string.flt_tag_shoujo,
+            R.string.flt_tag_shoujo_ai,
+            R.string.flt_tag_shounen,
+            R.string.flt_tag_shounen_ai,
+            R.string.flt_tag_slice_of_life,
+            R.string.flt_tag_smut,
+            R.string.flt_tag_sports,
+            R.string.flt_tag_staff_pick,
+            R.string.flt_tag_super_powers,
+            R.string.flt_tag_supernatural,
+            R.string.flt_tag_suspense,
+            R.string.flt_tag_tragedy,
+            R.string.flt_tag_vampire,
+            R.string.flt_tag_webtoon,
+            R.string.flt_tag_yaoi,
+            R.string.flt_tag_yuri,
+            R.string.flt_tag_no_chapters
+
     };
-    private static String[] genreV = new String[]{
-            "56", "1", "39", "2", "3", "59",
-            "84", "4", "5", "49", "45", "6", "7", "8", "9",
-            "10", "11", "12", "13", "14", "47", "15", "16",
-            "17", "37", "36", "18", "19", "51", "20",
-            "21", "54", "64", "22", "57", "23", "55",
-            "24", "38", "25", "26", "27", "28", "44",
-            "29", "48", "30", "42", "31", "46", "32",
-            "41", "33", "60", "62", "34", "53", "35",
-            "52", "58", "50", "40", "43", "61"
+    private static final String[] valGenre = {
+            "56",
+            "1",
+            "39",
+            "2",
+            "3",
+            "59",
+            "84",
+            "4",
+            "5",
+            "49",
+            "45",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "47",
+            "15",
+            "16",
+            "17",
+            "37",
+            "36",
+            "18",
+            "19",
+            "51",
+            "20",
+            "21",
+            "54%2C64",
+            "22%2C57",
+            "23",
+            "55",
+            "24%2C38",
+            "25",
+            "26",
+            "27",
+            "28",
+            "44%2C29%2C48",
+            "30",
+            "42%2C31%2C46",
+            "32",
+            "41",
+            "33",
+            "60",
+            "62",
+            "34",
+            "53",
+            "35",
+            "52",
+            "58%2C50",
+            "40",
+            "43",
+            "61"
     };
 
-    private static String[] orderV = {"/list/Hot-Book/", "/list/New-Update/", "/category/", "/list/New-Book/"};
-    private static String[] order = {"Popular Manga", "Latest Releases", "Manga Directory", "New Manga"};
-    private static String[] complete = new String[]{"Either", "Yes", "No"};
-    private static String[] completeV = new String[]{"either", "yes", "no"};
+    private static final int[] fltOrder = {
+            R.string.flt_order_views,
+            R.string.flt_order_last_update,
+            R.string.flt_order_alpha,
+            R.string.flt_order_newest
+    };
+    private static final String[] valOrder = {
+            "/list/Hot-Book/",
+            "/list/New-Update/",
+            "/category/",
+            "/list/New-Book/"
+    };
+
+    private static final int[] fltComplete = {
+            R.string.flt_status_all,
+            R.string.flt_status_completed,
+            R.string.flt_status_ongoing
+    };
+    private static final String[] valComplete = {
+            "either",
+            "yes",
+            "no"
+    };
 
     Taadd(Context context) {
         super(context);
-        this.setFlag(R.drawable.flag_en);
-        this.setIcon(R.drawable.taadd);
-        this.setServerName("Taadd");
-        setServerID(ServerBase.TAADD);
+        setFlag(R.drawable.flag_en);
+        setIcon(R.drawable.taadd);
+        setServerName("Taadd");
+        setServerID(TAADD);
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
     }
 
     @Override
@@ -63,68 +181,50 @@ class Taadd extends ServerBase {
 
     @Override
     public ArrayList<Manga> search(String term) throws Exception {
-        //http://my.taadd.com/search/es/?wd=naru
-        String source = getNavigatorWithNeededHeader().get("http://my.taadd.com/search/es/?wd=" + URLEncoder.encode(term, "UTF-8"));
+        term = URLEncoder.encode(term.replaceAll(" ", "+"), "UTF-8");
+        String source = getNavigatorAndFlushParameters()
+                .get("http://my.taadd.com/search/es/?wd=" + term);
         return getMangasFromSource(source);
     }
 
     @Override
     public void loadChapters(Manga manga, boolean forceReload) throws Exception {
-        if (manga.getChapters() == null || manga.getChapters().size() == 0 || forceReload)
-            loadMangaInformation(manga, forceReload);
+        loadMangaInformation(manga, forceReload);
     }
 
     @Override
     public void loadMangaInformation(Manga manga, boolean forceReload) throws Exception {
+        if (manga.getChapters().isEmpty() || forceReload) {
+            String source = getNavigatorAndFlushParameters().get(manga.getPath() + "?waring=1");
 
-        // replace old ninemanga links with new taadd links
-        /*if (manga.getPath().contains("ninemanga")) {
-            String path = manga.getPath().replace("http://ninemanga.com/manga/", "http://www.taadd.com/book/");
-            path = path.replace("https://ninemanga.com/manga/", "https://www.taadd.com/book/");
-            path = path.replaceAll("%20", "+");
-            manga.setPath(path);
-        }*/
+            // Cover
+            if (manga.getImages() == null || manga.getImages().isEmpty()) {
+                String img = getFirstMatchDefault("src=\"(http://pic\\.taadd\\.com/files/img/logo/[^\"]+)\"", source, "");
+                manga.setImages(img);
+            }
 
-        String source = getNavigatorWithNeededHeader().get(manga.getPath()+ "?waring=1");
-        //Log.d("NM","m.p: "+manga.getPath()+ "?waring=1");
+            // Summary
+            String summary = getFirstMatchDefault("Summary(.+?)</td>", source, context.getString(R.string.nodisponible));
+            manga.setSynopsis(summary);
 
-        // Cover
-        if (manga.getImages() == null || manga.getImages().isEmpty()) {
-            String img = getFirstMatchDefault("src=\"(http://pic\\.taadd\\.com/files/img/logo/[^\"]+)\"", source, "");
-            //Log.d("TD", "img: " + img);
-            manga.setImages(img);
+            // Status
+            manga.setFinished(source.contains(">Completed</a>"));
+
+            // Author
+            manga.setAuthor(getFirstMatchDefault("author-(.+?).html\">", source, context.getString(R.string.nodisponible)));
+
+            // Genre
+            manga.setGenre(getFirstMatchDefault("Categories:(.+?)</a>[^<]*</td>", source, context.getString(R.string.nodisponible))
+                    .replaceAll("<img[^>]+>", "").replaceAll("&nbsp;", "").replaceAll("</a>", ","));
+
+            // Chapters
+            Pattern p = Pattern.compile("href=\"(/chapter/[^-\"]+?)\">(.+?)</a>", Pattern.DOTALL);
+            Matcher matcher = p.matcher(source);
+            while (matcher.find()) {
+                Chapter chapter = new Chapter(matcher.group(2), HOST + matcher.group(1));
+                chapter.addChapterFirst(manga);
+            }
         }
-
-        // Summary
-        String summary = getFirstMatchDefault("Summary(.+?)</td>",source, defaultSynopsis);
-        //Log.d("TD","s: "+summary);
-        manga.setSynopsis(Util.getInstance().fromHtml(summary.replaceAll("</b><br/>", "")).toString());
-
-        // Status
-        //Log.d("TD","finished: "+getFirstMatchDefault("<td>Status:(.+?)</a>", source, "").contains("Completed"));
-        manga.setFinished(getFirstMatchDefault("<td>Status:(.+?)</a>", source, "").contains("Completed"));
-
-        // Author
-        manga.setAuthor(getFirstMatchDefault("author-(.+?).html\">", source, ""));
-
-        // Genre
-        //FIXME fix genres spacing
-        String genre = Util.getInstance().fromHtml(getFirstMatchDefault("Categories:(.+?)</td>", source, "").replaceAll("</a>", ",</a>")).toString();
-        //Log.d("TD", "g: " + genre.replaceAll("￼", ""));
-        if (genre.endsWith(","))
-            genre = genre.substring(2, genre.length() - 1);
-        manga.setGenre(genre.replaceAll("￼", ""));
-
-        // Chapters
-        Pattern p = Pattern.compile("href=\"(/chapter/[^-\"]+?)\">(.+?)</a>", Pattern.DOTALL);
-        Matcher matcher = p.matcher(source);
-        ArrayList<Chapter> chapters = new ArrayList<>();
-        while (matcher.find()) {
-            /*Log.d("TD", "1: " + matcher.group(1));
-            Log.d("TD", "2: " + matcher.group(2));*/
-            chapters.add(0, new Chapter(matcher.group(2), HOST + matcher.group(1)));
-        }
-        manga.setChapters(chapters);
     }
 
     @Override
@@ -134,29 +234,35 @@ class Taadd extends ServerBase {
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
-        Navigator nav = getNavigatorWithNeededHeader();
+        Navigator nav = getNavigatorAndFlushParameters();
         nav.addHeader("Referer", chapter.getPath());
         String source = nav.get(chapter.getPath() + "-" + page + ".html");
-        //Log.d("TD", "web: " + chapter.getPath() + "-" + page + ".html");
-        return getFirstMatchDefault("src=\"(http[s]?://pic\\.taadd\\.com/comics/[^\"]+?|http[s]?://pic\\d+\\.taadd\\.com/comics/[^\"]+?)\"", source, "Error getting image");
+        return getFirstMatchDefault("src=\"(http[s]?://pic\\.taadd\\.com/comics/[^\"]+?|http[s]?://pic\\d+\\.taadd\\.com/comics/[^\"]+?)\"", source, "Error: failed to get image link");
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
-        String source = getNavigatorWithNeededHeader().get(chapter.getPath());
+        String source = getNavigatorAndFlushParameters().get(chapter.getPath());
         String pageNumber = getFirstMatchDefault("\">(\\d+)</option>[\\s]*</select>", source,
-                "failed to get the number of pages");
-        //Log.d("TD", "p: " + pagenumber);
+                "Error: failed to get the number of pages");
         chapter.setPages(Integer.parseInt(pageNumber));
     }
 
     @Override
     public ServerFilter[] getServerFilters() {
         return new ServerFilter[]{
-                new ServerFilter("Included Genre(s)", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Excluded Genre(s)", genre, ServerFilter.FilterType.MULTI),
-                new ServerFilter("Completed Series", complete, ServerFilter.FilterType.SINGLE),
-                new ServerFilter("Order (only applied when no genre is selected)", order, ServerFilter.FilterType.SINGLE)
+                new ServerFilter(
+                        context.getString(R.string.flt_include_tags),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_exclude_tags),
+                        buildTranslatedStringArray(fltGenre), ServerFilter.FilterType.MULTI),
+                new ServerFilter(
+                        context.getString(R.string.flt_status),
+                        buildTranslatedStringArray(fltComplete), ServerFilter.FilterType.SINGLE),
+                new ServerFilter(
+                        context.getString(R.string.flt_order) + " (" + context.getString(R.string.flt_is_exclusive) + ")",
+                        buildTranslatedStringArray(fltOrder), ServerFilter.FilterType.SINGLE)
         };
     }
 
@@ -165,16 +271,7 @@ class Taadd extends ServerBase {
         Matcher matcher = pattern.matcher(source);
         ArrayList<Manga> mangas = new ArrayList<>();
         while (matcher.find()) {
-            /*Log.d("TD", "1: " + matcher.group(1));
-            Log.d("TD", "2: " + matcher.group(2));
-            Log.d("TD", "3: " + matcher.group(3));*/
-            String title = Util.getInstance().fromHtml(matcher.group(3)).toString();
-            //Log.d("TD","t0: "+title);
-            if (title.equals(title.toUpperCase())) {
-                title = Util.getInstance().toCamelCase(title.toLowerCase());
-                //Log.d("TD","t1: "+title);
-            }
-            Manga manga = new Manga(getServerID(), title, matcher.group(1), false);
+            Manga manga = new Manga(getServerID(), matcher.group(3), matcher.group(1), false);
             manga.setImages(matcher.group(2));
             mangas.add(manga);
         }
@@ -186,34 +283,22 @@ class Taadd extends ServerBase {
         String includedGenres = "";
         if (filters[0].length > 0) {
             for (int i = 0; i < filters[0].length; i++) {
-                includedGenres = includedGenres + genreV[filters[0][i]] + "%2C"; // comma
+                includedGenres = includedGenres + valGenre[filters[0][i]] + "%2C"; // comma
             }
         }
         String excludedGenres = "";
         if (filters[1].length > 0) {
             for (int i = 0; i < filters[1].length; i++) {
-                excludedGenres = excludedGenres + genreV[filters[1][i]] + "%2C"; // comma
+                excludedGenres = excludedGenres + valGenre[filters[1][i]] + "%2C"; // comma
             }
         }
         String web;
-        if (filters[0].length < 1 && filters[1].length < 1)
-            web = HOST + orderV[filters[3][0]];
-        else
-            web = "http://taadd.com/search/?name_sel=contain&wd=&author_sel=contain&author=&artist_sel=contain&artist=&category_id=" + includedGenres + "&out_category_id=" + excludedGenres + "&completed_series=" + completeV[filters[2][0]] + "&type=high&page=" + pageNumber + ".html";
-        //Log.d("TD","web: "+web);
-        String source = getNavigatorWithNeededHeader().get(web);
-        return getMangasFromSource(source);
-    }
-
-    public Navigator getNavigatorWithNeededHeader() throws Exception {
-        Navigator nav = new Navigator(context);
-        nav.addHeader("Accept-Language", "es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3");
-        return nav;
-    }
-
-    @Override
-    public boolean hasList() {
-        return false;
+        if (filters[0].length < 1 && filters[1].length < 1) {
+            web = HOST + valOrder[filters[3][0]];
+        }
+        else {
+            web = HOST + "/search/?name_sel=contain&wd=&author_sel=contain&author=&artist_sel=contain&artist=&category_id=" + includedGenres + "&out_category_id=" + excludedGenres + "&completed_series=" + valComplete[filters[2][0]] + "&type=high&page=" + pageNumber + ".html";
+        }
+        return getMangasFromSource(getNavigatorAndFlushParameters().get(web));
     }
 }
-

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -412,4 +412,10 @@
     <string name="flt_order_numchapters">Anzahl der Kapitel</string>
     <string name="flt_tag_automobiles">Autos</string>
     <string name="flt_tag_outer_space">Weltall</string>
+    <string name="flt_order_artist">Künstler</string>
+    <string name="flt_order_default">Standard</string>
+    <string name="flt_order_ascending">aufsteigend</string>
+    <string name="flt_order_author">Autor</string>
+    <string name="flt_order_by">Ordnen nach</string>
+    <string name="flt_order_descending">absteigend</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -399,4 +399,5 @@
     <string name="flt_tag_detective">Detektiv</string>
     <string name="flt_tag_kodomo">Kodomo</string>
     <string name="flt_tag_maho_shoujo">Maho Shoujo</string>
+    <string name="flt_tag_light_novel">Light Novel</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -407,4 +407,5 @@
     <string name="flt_status_suspended">ausgesetzt</string>
     <string name="flt_order_title">Titel</string>
     <string name="flt_order_chapters">Kapitel</string>
+    <string name="flt_order_similar">Ähnliche</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -410,4 +410,6 @@
     <string name="flt_order_similar">Ähnliche</string>
     <string name="flt_is_exclusive">kann nur exklusiv benutzt werden</string>
     <string name="flt_order_numchapters">Anzahl der Kapitel</string>
+    <string name="flt_tag_automobiles">Autos</string>
+    <string name="flt_tag_outer_space">Weltall</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -409,4 +409,5 @@
     <string name="flt_order_chapters">Kapitel</string>
     <string name="flt_order_similar">Ähnliche</string>
     <string name="flt_is_exclusive">kann nur exklusiv benutzt werden</string>
+    <string name="flt_order_numchapters">Anzahl der Kapitel</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -408,4 +408,5 @@
     <string name="flt_order_title">Titel</string>
     <string name="flt_order_chapters">Kapitel</string>
     <string name="flt_order_similar">Ähnliche</string>
+    <string name="flt_is_exclusive">kann nur exklusiv benutzt werden</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -400,4 +400,8 @@
     <string name="flt_tag_kodomo">Kodomo</string>
     <string name="flt_tag_maho_shoujo">Maho Shoujo</string>
     <string name="flt_tag_light_novel">Light Novel</string>
+    <string name="flt_tag_comic">Comic</string>
+    <string name="flt_tag_lolicon">Lolicon</string>
+    <string name="flt_tag_shotacon">Shotacon</string>
+    <string name="flt_order_newest">Neueste</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -418,4 +418,10 @@
     <string name="flt_order_author">Autor</string>
     <string name="flt_order_by">Ordnen nach</string>
     <string name="flt_order_descending">absteigend</string>
+    <string name="flt_status_abandoned">Aufgegeben</string>
+    <string name="flt_status_one_shot">Eintagsfliege</string>
+    <string name="flt_tag_magazine">Magazin</string>
+    <string name="flt_tag_manfra">Manfra</string>
+    <string name="flt_tag_perverted">Pervers</string>
+    <string name="flt_tag_travel">Reisen</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -404,4 +404,7 @@
     <string name="flt_tag_lolicon">Lolicon</string>
     <string name="flt_tag_shotacon">Shotacon</string>
     <string name="flt_order_newest">Neueste</string>
+    <string name="flt_status_suspended">ausgesetzt</string>
+    <string name="flt_order_title">Titel</string>
+    <string name="flt_order_chapters">Kapitel</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -411,4 +411,6 @@
     <string name="flt_order_similar">Similar</string>
     <string name="flt_is_exclusive">can only be used exclusively</string>
     <string name="flt_order_numchapters">Number of Chapters</string>
+    <string name="flt_tag_automobiles">Automobiles</string>
+    <string name="flt_tag_outer_space">Outer Space</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -400,4 +400,5 @@
     <string name="flt_tag_detective">Detective</string>
     <string name="flt_tag_kodomo">Kodomo</string>
     <string name="flt_tag_maho_shoujo">Maho Shoujo</string>
+    <string name="flt_tag_light_novel">Light Novel</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -409,4 +409,5 @@
     <string name="flt_order_title">Title</string>
     <string name="flt_order_chapters">Chapters</string>
     <string name="flt_order_similar">Similar</string>
+    <string name="flt_is_exclusive">can only be used exclusively</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -401,4 +401,8 @@
     <string name="flt_tag_kodomo">Kodomo</string>
     <string name="flt_tag_maho_shoujo">Maho Shoujo</string>
     <string name="flt_tag_light_novel">Light Novel</string>
+    <string name="flt_order_newest">Newest</string>
+    <string name="flt_tag_comic">Comic</string>
+    <string name="flt_tag_lolicon">Lolicon</string>
+    <string name="flt_tag_shotacon">Shotacon</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -408,4 +408,5 @@
     <string name="flt_status_suspended">Suspended</string>
     <string name="flt_order_title">Title</string>
     <string name="flt_order_chapters">Chapters</string>
+    <string name="flt_order_similar">Similar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,4 +413,10 @@
     <string name="flt_order_numchapters">Number of Chapters</string>
     <string name="flt_tag_automobiles">Automobiles</string>
     <string name="flt_tag_outer_space">Outer Space</string>
+    <string name="flt_order_default">Default</string>
+    <string name="flt_order_author">Author</string>
+    <string name="flt_order_artist">Artist</string>
+    <string name="flt_order_ascending">ascending</string>
+    <string name="flt_order_descending">descending</string>
+    <string name="flt_order_by">Order by</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -410,4 +410,5 @@
     <string name="flt_order_chapters">Chapters</string>
     <string name="flt_order_similar">Similar</string>
     <string name="flt_is_exclusive">can only be used exclusively</string>
+    <string name="flt_order_numchapters">Number of Chapters</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,4 +419,10 @@
     <string name="flt_order_ascending">ascending</string>
     <string name="flt_order_descending">descending</string>
     <string name="flt_order_by">Order by</string>
+    <string name="flt_tag_magazine">Magazine</string>
+    <string name="flt_tag_manfra">Manfra</string>
+    <string name="flt_status_abandoned">Abandoned</string>
+    <string name="flt_status_one_shot">One Shot</string>
+    <string name="flt_tag_perverted">Perverted</string>
+    <string name="flt_tag_travel">Travel</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,4 +405,7 @@
     <string name="flt_tag_comic">Comic</string>
     <string name="flt_tag_lolicon">Lolicon</string>
     <string name="flt_tag_shotacon">Shotacon</string>
+    <string name="flt_status_suspended">Suspended</string>
+    <string name="flt_order_title">Title</string>
+    <string name="flt_order_chapters">Chapters</string>
 </resources>


### PR DESCRIPTION
This is an update for #461.

@raulhaag: #461 introduced an issue... By not removing the newline characters from the HTML, some matches will now fail - even if `Pattern.DOTALL` is used. The option implies to treat newlines as regular characters. Which means, they still represent a character. If this is not accounted for, the match will fail (e.g. see `RawSenManga`).

So basically each server needs to be tested... I have written up some test procedure in the JavaDoc part of `ServerBase`.

As of now, these servers have been tested by me according to the procedure. I will continue and rework the other classes as well, but it will take some time.

- MangaHere
- MangaTown
- RawSenManga
- JapScan
- KissManga
- MangaEden
- MangaStream
- mangapanda
- mangareader.net
- Taadd
- ReadMangaToday
- MangaFox
- MangaEdenIt
- SubManga
- MangaKawaii
- LeoManga
- Kumanga
- Mangapedia
- NineManga
(NineManga and its subdomains work as well, but image loading is currently defunct. see comment on #461)

**Until then, there may be potential regressions, so please do not push a new release until the servers are tested ok. Otherwise users will start complaining about the servers not working.**

This pull request also includes improvements for using the `Manga` and `Chapter` classes as they clean up the strings (HTML to string, unescaping of HTML) passed via their setters themselves. This reduces the code in the server part and makes it more readable.

Some documentation update and further annotations were added.