### PR TITLE
Bugfix: getImageFrom() not used one-based

### DIFF
--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaKawaii.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaKawaii.java
@@ -109,28 +109,30 @@ class MangaKawaii extends ServerBase {
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
-        if (chapter.getExtra() == null || chapter.getExtra().length() < 2) {
-            setExtra(chapter);
+        chapterInit(chapter);
+
+        if (page < 1) {
+            page = 1;
         }
-        return chapter.getExtra().split("\\|")[page];
-    }
-
-    private int setExtra(Chapter chapter) throws Exception {
-        String source = getNavigatorAndFlushParameters().get(chapter.getPath());
-        String tmpImages = getFirstMatchDefault("<div id=\"all\"(.+?)</div>", source, "");
-
-        ArrayList<String> matches = getAllMatch("data-src='.(https://www\\.mangakawaii\\.com/uploads/[^\"]+?).'", tmpImages);
-        chapter.setExtra(TextUtils.join("|", matches));
-
-        return matches.size();
+        if (page > chapter.getPages()) {
+            page = chapter.getPages();
+        }
+        assert chapter.getExtra() != null;
+        return chapter.getExtra().split("\\|")[page - 1];
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
-        if (chapter.getExtra() == null || chapter.getExtra().length() < 2) {
-            chapter.setPages(setExtra(chapter));
-        } else {
-            chapter.setPages(0);
+        if (chapter.getExtra() == null) {
+            String source = getNavigatorAndFlushParameters().get(chapter.getPath());
+            String tmpImages = getFirstMatchDefault("<div id=\"all\"(.+?)</div>", source, "");
+            ArrayList<String> images = getAllMatch("data-src='.(https://www\\.mangakawaii\\.com/uploads/[^\"]+?).'", tmpImages);
+
+            if(images.isEmpty()) {
+                throw new Exception("No image links found for this chapter.");
+            }
+            chapter.setPages(images.size());
+            chapter.setExtra(TextUtils.join("|", images));
         }
     }
 

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/Mangapedia.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/Mangapedia.java
@@ -280,25 +280,30 @@ class Mangapedia extends ServerBase {
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
+        chapterInit(chapter);
+
         if (page < 1) {
             page = 1;
         }
         if (page > chapter.getPages()) {
             page = chapter.getPages();
         }
-        String extra = chapter.getExtra();
-        if (extra != null) {
-            return extra.split("\\|")[page];
-        }
-        throw new Exception("Error: no image link for this page");
+        assert chapter.getExtra() != null;
+        return chapter.getExtra().split("\\|")[page - 1];
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
-        String data = getNavigatorAndFlushParameters().get(chapter.getPath());
-        ArrayList<String> images = getAllMatch("['|\"](http[s]*://mangapedia.fr/project_code/script/image.php\\?path=.+?)['|\"]", data);
-        chapter.setPages(images.size());
-        chapter.setExtra(TextUtils.join("|", images));
+        if(chapter.getExtra() == null) {
+            String data = getNavigatorAndFlushParameters().get(chapter.getPath());
+            ArrayList<String> images = getAllMatch("['|\"](http[s]*://mangapedia.fr/project_code/script/image.php\\?path=.+?)['|\"]", data);
+
+            if (images.isEmpty()) {
+                throw new Exception("No image links found for this chapter.");
+            }
+            chapter.setPages(images.size());
+            chapter.setExtra(TextUtils.join("|", images));
+        }
     }
 
     @Override

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ServerBase.java
@@ -460,7 +460,7 @@ public abstract class ServerBase {
      * page lies within the available page numbers of the given Chapter.
      *
      * @param chapter a Chapter object to get the page image URL for
-     * @param page    the page number
+     * @param page    the page number starting at page 1 (NOT zero based)
      * @return the URL to the image on the given page of the Chapter
      * @throws Exception if an error occurred
      */

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/ViewComic.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/ViewComic.java
@@ -114,32 +114,32 @@ class ViewComic extends ServerBase {
 
     @Override
     public String getImageFrom(Chapter chapter, int page) throws Exception {
-        if (chapter.getExtra() == null || chapter.getExtra().length() < 2) {
-            setExtra(chapter);
-        }
-        return chapter.getExtra().split("\\|")[page];
-    }
+        chapterInit(chapter);
 
-    private int setExtra(Chapter chapter) throws Exception {
-        String source = getNavigatorAndFlushParameters().get(chapter.getPath());
-
-        ArrayList<String> images = getAllMatch("src=\"(http[s]?://\\d+\\.bp\\.blogspot\\.com/.+?)\"", source);
-        if(!images.isEmpty()) {
-            chapter.setExtra(TextUtils.join("|", images));
+        if (page < 1) {
+            page = 1;
         }
-        else {
-            images = getAllMatch("src=\"(//\\d+\\.bp\\.blogspot\\.com/.+?)\"", source);
-            chapter.setExtra(TextUtils.join("|", images));
+        if (page > chapter.getPages()) {
+            page = chapter.getPages();
         }
-        return images.size();
+        assert chapter.getExtra() != null;
+        return chapter.getExtra().split("\\|")[page - 1];
     }
 
     @Override
     public void chapterInit(Chapter chapter) throws Exception {
-        if (chapter.getExtra() == null || chapter.getExtra().length() < 2) {
-            chapter.setPages(setExtra(chapter));
-        } else {
-            chapter.setPages(0);
+        if (chapter.getExtra() == null) {
+            String source = getNavigatorAndFlushParameters().get(chapter.getPath());
+            ArrayList<String> images = getAllMatch("src=\"(http[s]?://\\d+\\.bp\\.blogspot\\.com/.+?)\"", source);
+            if(images.isEmpty()) {
+                images = getAllMatch("src=\"(//\\d+\\.bp\\.blogspot\\.com/.+?)\"", source);
+            }
+
+            if(images.isEmpty()) {
+                throw new Exception("No image links found for this chapter.");
+            }
+            chapter.setExtra(TextUtils.join("|", images));
+            chapter.setPages(images.size());
         }
     }
 


### PR DESCRIPTION
During rework and code cleanup I have by mistake changed the semantics for accesses for some Manga servers from implicitly one-based to zero-based which results in the last page missing (and the first page being skipped).
This happens for all servers which were changed to use `TextUtils.join()` on the resulting list of images to fill `Chapter.extra` via `getAllMatch().`
This behaviour has now been fixed for all affected servers. Also additional error checking was introduced and made consistent.

@raulhaag please review my changes before pulling. I have simplified the checks for `getExtra()`. Now only returning of `null` is checked (not additionally the length being less than 2). Either there is at least one page or none (in this case `chapterInit()` would raise an exception.
This is also the intention when not performing additional checks for the array index, besides:
* `chapterInit()` (which is always called) did not throw an exception
* this means the list is splitable (i.e. non-empty)
The assertion before is just used to silence the warning in Android Studio.