### PR TITLE
MangaPanda: fix wrong host stored in DB

### DIFF
--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaPanda.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaPanda.java
@@ -13,7 +13,7 @@ import ar.rulosoft.mimanganu.componentes.ServerFilter;
 import ar.rulosoft.mimanganu.utils.Util;
 
 class MangaPanda extends ServerBase {
-    private static String HOST = "http://www.mangapanda.com";
+    private String HOST = "http://www.mangapanda.com";
 
     private static final String PATTERN_SERIE =
             "<li><a href=\"([^\"]+)\">([^<]+)";
@@ -107,8 +107,8 @@ class MangaPanda extends ServerBase {
         setServerID(MANGAPANDA);
     }
 
-    void SetHost(String new_host) {
-        HOST = new_host;
+    void setHost(String host) {
+        HOST = host;
     }
 
     @Override

--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaReader.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaReader.java
@@ -21,6 +21,6 @@ class MangaReader extends MangaPanda {
         setServerName("mangareader.net");
         setServerID(MANGAREADER);
 
-        SetHost("http://www.mangareader.net");
+        setHost("http://www.mangareader.net");
     }
 }


### PR DESCRIPTION
The `static` host field of the parent class (`MangaPanda`) gets set permanently (as there is only one memory location) by the call to `setHost` on the derived class (`MangaReader`). As the derived class is instantiated at a later point in time, it overwrites the parent class' `HOST`.
Removing the `static` qualifier fixes this.

`SetHost` was renamed, to fit better into the other code.

Fixes #479.