### PR TITLE
Minor fixes and .nomedia handling

### DIFF
--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaFox.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaFox.java
@@ -30,7 +30,7 @@ class MangaFox extends ServerBase {
     private static final String PATTERN_MANGA =
             "\"([^\"]+store.manga.+?)\".+?href=\"([^\"]+)[^>]+>([^<]+)";
     private static final String PATTERN_MANGA_SEARCH =
-            "<a class=\"title series_preview top\" href=\"([^\"]+)\"[^>]+([^<]+)";
+            "<a class=\"title series_preview top\" href=\"([^\"]+)\"[^>]+>([^<]+)";
 
     private static final int[] fltGenre = {
             R.string.flt_tag_action,

--- a/app/src/main/java/ar/rulosoft/mimanganu/utils/TestServersCommon.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/utils/TestServersCommon.java
@@ -35,9 +35,10 @@ public class TestServersCommon {
      * Create a common test case to be used for host based unit tests or tests using the
      * instrumentation API (i.e. device based testing).
      *
-     * @param serverBase     the <code>ServerBase</code> instance to test
+     * @param serverId       the id to get the proper <code>ServerBase</code> instance to test
      * @param hostBasedTests <code>true</code> if tests are to be run on the host, <code>false</code>
      *                       otherwise
+     * @param context        the <code>Context</code> to use during testing
      * @throws Exception     if something goes wrong
      */
     public TestServersCommon(int serverId, boolean hostBasedTests, Context context) throws Exception {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -45,7 +45,7 @@
     <string name="descargando">(Lädt herunter)</string>
     <string name="error">(Fehler)</string>
     <string name="paused">(Angehalten)</string>
-    <string name="esconder_de_galeria_subtitle">Heruntergeladene Bilder nicht in der Galerie anzeigen.</string>
+    <string name="esconder_de_galeria_subtitle">Heruntergeladene Bilder nicht in der Gallerie anzeigen. Ein Geräteneustart kann zum Übernehmen der Änderung notwendig sein.</string>
     <string name="escondergaleria">Bilder verbergen</string>
     <string name="hide_read">Gelesene ausblenden</string>
     <string name="estado">Status</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="descargando">(Downloading)</string>
     <string name="error">(Error)</string>
     <string name="paused">(Paused)</string>
-    <string name="esconder_de_galeria_subtitle">Hide downloaded images from gallery</string>
+    <string name="esconder_de_galeria_subtitle">Hide downloaded images from the gallery. A device restart might be needed for a change to take effect.</string>
     <string name="escondergaleria">Hide from gallery</string>
     <string name="hide_read">Hide already read</string>
     <string name="estado">Status</string>


### PR DESCRIPTION
* fixed an excess character for MangaFox
* fixed outdated JavaDoc
* fixed #491 (or at least improved the `.nomedia` handling for hiding the images in the gallery app)

A hint for eventually needing a device restart was added to the preference menu.