### PR TITLE
MangaTown: remove workaround for 503 - no longer needed

### DIFF
--- a/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaTown.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/servers/MangaTown.java
@@ -169,14 +169,7 @@ class MangaTown extends ServerBase {
     public String getImageFrom(Chapter chapter, int page) throws Exception {
         assert chapter.getExtra() != null;
         String web = "http:" + chapter.getExtra().split("\\|")[page - 1];
-        String data = getNavigatorAndFlushParameters().getAndReturnResponseCodeOnFailure(web);
-
-        // if polled too quickly, the server will respond with 503 - throttle here if needed
-        if(data.equals("503")) {
-            Thread.sleep(500);
-            data = getNavigatorAndFlushParameters().get(web);
-        }
-
+        String data = getNavigatorAndFlushParameters().get(web);
         return getFirstMatch(
                 PATTERN_IMAGE, data,
                 context.getString(R.string.server_failed_loading_image));


### PR DESCRIPTION
~~This is the same solution as for MangaTown and works for me.~~

~~If more servers switch to the same kind of protection, it would be good to consider creating some kind of generic functionality for throttling all servers (e.g. also adding some amount of randomness).~~

Fixed by 7de8901.