### PR TITLE
Fix potential  NPE

### DIFF
--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/readers/continuos/ReaderContinuous.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/readers/continuos/ReaderContinuous.java
@@ -326,8 +326,8 @@ public abstract class ReaderContinuous extends Reader implements GestureDetector
                 BitmapFactory.decodeStream(inputStream, null, bitmapOptions);
                 dimension.original_width = bitmapOptions.outWidth;
                 dimension.original_height = bitmapOptions.outHeight;
-                if (inputStream!=null){
-                	inputStream.close();
+                if (inputStream != null){
+                    inputStream.close();
                 }
             } catch (IOException ignored) {
             }

--- a/app/src/main/java/ar/rulosoft/mimanganu/componentes/readers/continuos/ReaderContinuous.java
+++ b/app/src/main/java/ar/rulosoft/mimanganu/componentes/readers/continuos/ReaderContinuous.java
@@ -326,7 +326,9 @@ public abstract class ReaderContinuous extends Reader implements GestureDetector
                 BitmapFactory.decodeStream(inputStream, null, bitmapOptions);
                 dimension.original_width = bitmapOptions.outWidth;
                 dimension.original_height = bitmapOptions.outHeight;
-                inputStream.close();
+                if (inputStream!=null){
+                	inputStream.close();
+                }
             } catch (IOException ignored) {
             }
             dimension.initValues();


### PR DESCRIPTION
We have developed a static check tool [NPEDetector](https://github.com/lujiefsi/NPEDetector) which can find  the potential  null pointer exception. It has found 65 NPE bugs and most of them are confirmed by origin developer. 

We have found a potential  NPE  while scanning this project. We carefully analysis the reason:
<pre>
// app/src/main/java/ar/rulosoft/mimanganu/componentes/readers/continuos/ReaderContinuous.java
    private InputStream getBitmapFromAsset(String strName) {
        AssetManager assetManager = getContext().getAssets();
        InputStream iStr = null;
        try {
            iStr = assetManager.open(strName);
        } catch (IOException e) {
            e.printStackTrace();// the iStr wil be null
        }
        return iStr;
    }
</pre>

The _getBitmapFromAsset_ will return null while meeting IOException, and it has two callers. 
One caller has null check by catching NPE just like:
<pre>
catch (Exception | OutOfMemoryError e) {
        e.printStackTrace();
 }
</pre>

but another caller doesn't have:
<pre>
protected Page initValues(String path) {
       .......
       else {
            try {
                dimension.error = true;
                InputStream inputStream = getBitmapFromAsset("broke.png");
                BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
                bitmapOptions.inJustDecodeBounds = true;
                BitmapFactory.decodeStream(inputStream, null, bitmapOptions);//won't throw IOException 
                dimension.original_width = bitmapOptions.outWidth;
                dimension.original_height = bitmapOptions.outHeight;
                inputStream.close();// NPE may happen
            } catch (IOException ignored) {
            }
        }
    }
</pre>

BitmapFactory.decodeStream  allow inputStream to be null and won't throw IOException:
<pre>
    public static Bitmap decodeStream(@Nullable InputStream is, @Nullable Rect outPadding,
            @Nullable Options opts) {
        // we don't throw in this case, thus allowing the caller to only check
        // the cache, and not force the image to be decoded.
        if (is == null) {
            return null;
        }
</pre>

so _inputStream.close();_ will cause NPE.
We have fixed it by adding null check.But due to we are not very familiar with MiMangaNu， please tell us whether this NPE can happen and the fix is right!




 
