### PR TITLE
Use suffix for Github build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,12 +44,12 @@ android {
     productFlavors {
         fdroid {
             signingConfig signingConfigs.release
-            versionNameSuffix '-fdroid'
             dimension "builds"
         }
         github {
             signingConfig signingConfigs.release
              //removed to maintain updates as now are
+            versionNameSuffix '-github'
             dimension "builds"
         }
     }


### PR DESCRIPTION
...so F-Droid can actually use autoupdates and not how it works now ( fdroidbot fails since it can't yet handle a suffix and a human needs to fix it: https://gitlab.com/fdroid/fdroiddata/commits/master/metadata/ar.rulosoft.mimanganu.txt )

You basically know that the builds that are not `-github` are....F-Droid.